### PR TITLE
Add open-in-tab PDFs and avoid redundant reloads

### DIFF
--- a/src/components/ExportButtons.tsx
+++ b/src/components/ExportButtons.tsx
@@ -27,6 +27,8 @@ interface ExportButtonsProps {
   excelFileName?: string;
   pdfFileName?: string;
   ticketFileName?: string;
+  downloadPdf?: boolean;
+  downloadTicket?: boolean;
   onExcelDownload?: () => void | Promise<void>;
   onPdfDownload?: () => void | Promise<void>;
   onTicketDownload?: () => void | Promise<void>;
@@ -46,6 +48,8 @@ export default function ExportButtons({
   excelFileName = "export.xlsx",
   pdfFileName = "export.pdf",
   ticketFileName = "ticket.pdf",
+  downloadPdf = false,
+  downloadTicket = false,
   onExcelDownload,
   onPdfDownload,
   onTicketDownload,
@@ -67,6 +71,14 @@ export default function ExportButtons({
     link.click();
     link.remove();
     window.URL.revokeObjectURL(url);
+  };
+
+  const openPdfInNewTab = async (endpoint: string) => {
+    const response = await api.get(endpoint, { responseType: "blob" });
+    const url = window.URL.createObjectURL(
+      new Blob([response.data], { type: "application/pdf" })
+    );
+    window.open(url, "_blank");
   };
 
   const handleExcelDownload = () => {
@@ -102,12 +114,14 @@ export default function ExportButtons({
 
     if (!pdfEndpoint) return;
 
-    const download = downloadFile(pdfEndpoint, pdfFileName);
+    const download = downloadPdf
+      ? downloadFile(pdfEndpoint, pdfFileName)
+      : openPdfInNewTab(pdfEndpoint);
 
     promiseToast(download, {
-      loading: "Descargando PDF...",
-      success: "PDF descargado exitosamente",
-      error: "Error al descargar el archivo PDF",
+      loading: downloadPdf ? "Descargando PDF..." : "Abriendo PDF...",
+      success: downloadPdf ? "PDF descargado exitosamente" : "PDF abierto exitosamente",
+      error: downloadPdf ? "Error al descargar el archivo PDF" : "Error al abrir el archivo PDF",
     });
   };
 
@@ -123,12 +137,14 @@ export default function ExportButtons({
 
     if (!ticketEndpoint) return;
 
-    const download = downloadFile(ticketEndpoint, ticketFileName);
+    const download = downloadTicket
+      ? downloadFile(ticketEndpoint, ticketFileName)
+      : openPdfInNewTab(ticketEndpoint);
 
     promiseToast(download, {
-      loading: "Descargando ticket...",
-      success: "Ticket descargado exitosamente",
-      error: "Error al descargar el ticket",
+      loading: downloadTicket ? "Descargando ticket..." : "Abriendo ticket...",
+      success: downloadTicket ? "Ticket descargado exitosamente" : "Ticket abierto exitosamente",
+      error: downloadTicket ? "Error al descargar el ticket" : "Error al abrir el ticket",
     });
   };
 

--- a/src/pages/guide/components/GuideAddPage.tsx
+++ b/src/pages/guide/components/GuideAddPage.tsx
@@ -66,6 +66,7 @@ const mapGuideToDefaultValues = (guide: GuideResource): Partial<GuideSchema> => 
       unit_measure: detail.unit_measure || "UND",
       weight: Number(detail.weight) || 0,
     })),
+    total_weight: Number(guide.total_weight) || 0,
     total_packages: guide.total_packages || 0,
   };
 };

--- a/src/pages/guide/components/GuideForm.tsx
+++ b/src/pages/guide/components/GuideForm.tsx
@@ -151,7 +151,10 @@ export const GuideForm = ({
   warehouses,
   motives,
 }: GuideFormProps) => {
-  const initialOrderId = useRef(mode === "edit" ? defaultValues.order_id : null);
+  const initialOrderId = useRef(defaultValues.order_id || null);
+  const initialSaleId = useRef(defaultValues.sale_id || null);
+  const initialPurchaseId = useRef(defaultValues.purchase_id || null);
+  const initialWarehouseDocumentId = useRef(defaultValues.warehouse_document_id || null);
   const [details, setDetails] = useState<DetailRow[]>([]);
   const [editingDetailIndex, setEditingDetailIndex] = useState<number | null>(
     null,
@@ -270,6 +273,8 @@ export const GuideForm = ({
   useEffect(() => {
     const loadSale = async () => {
       if (saleId && saleId !== "") {
+        // No recargar si el ID no cambió respecto al inicial (edición o duplicación)
+        if (saleId === initialSaleId.current) return;
         // Limpiar otros documentos seleccionados
         if (orderId) form.setValue("order_id", "");
         if (purchaseId) form.setValue("purchase_id", "");
@@ -316,6 +321,8 @@ export const GuideForm = ({
   useEffect(() => {
     const loadPurchase = async () => {
       if (purchaseId && purchaseId !== "") {
+        // No recargar si el ID no cambió respecto al inicial (edición o duplicación)
+        if (purchaseId === initialPurchaseId.current) return;
         // Limpiar otros documentos seleccionados
         if (orderId) form.setValue("order_id", "");
         if (saleId) form.setValue("sale_id", "");
@@ -357,6 +364,8 @@ export const GuideForm = ({
   useEffect(() => {
     const loadWarehouseDocument = async () => {
       if (warehouseDocumentId && warehouseDocumentId !== "") {
+        // No recargar si el ID no cambió respecto al inicial (edición o duplicación)
+        if (warehouseDocumentId === initialWarehouseDocumentId.current) return;
         // Limpiar otros documentos seleccionados
         if (orderId) form.setValue("order_id", "");
         if (saleId) form.setValue("sale_id", "");

--- a/src/pages/sale/lib/sale.interface.ts
+++ b/src/pages/sale/lib/sale.interface.ts
@@ -44,6 +44,14 @@ export interface SaleInstallmentResource {
   created_at: string;
   updated_at: string;
   currency: string;
+  // Optional fields from sale relationship
+  sale_issue_date?: string;
+  customer_name?: string;
+  customer_document?: string;
+  order_purchase?: string;
+  guides?: string;
+  retention?: number;
+  credit_note?: number;
 }
 
 export interface SaleResource {


### PR DESCRIPTION
ExportButtons: add downloadPdf and downloadTicket flags (default false) and implement openPdfInNewTab to open PDF/ticket blobs in a new tab; use flags to choose between downloading or opening and update toast messages accordingly. Guide components: set total_weight default in mapGuideToDefaultValues; initialize refs for order/sale/purchase/warehouse_document IDs and skip reloading related documents when the selected ID equals the initial (prevents redundant fetches on edit/duplicate). Sale interface: extend SaleInstallmentResource with optional sale-related fields (sale_issue_date, customer_name, customer_document, order_purchase, guides, retention, credit_note).