### PR TITLE
Add openDirect option to export buttons

### DIFF
--- a/src/components/ExportButtons.tsx
+++ b/src/components/ExportButtons.tsx
@@ -29,6 +29,7 @@ interface ExportButtonsProps {
   ticketFileName?: string;
   downloadPdf?: boolean;
   downloadTicket?: boolean;
+  openDirect?: boolean;
   onExcelDownload?: () => void | Promise<void>;
   onPdfDownload?: () => void | Promise<void>;
   onTicketDownload?: () => void | Promise<void>;
@@ -50,6 +51,7 @@ export default function ExportButtons({
   ticketFileName = "ticket.pdf",
   downloadPdf = false,
   downloadTicket = false,
+  openDirect = false,
   onExcelDownload,
   onPdfDownload,
   onTicketDownload,
@@ -79,6 +81,12 @@ export default function ExportButtons({
       new Blob([response.data], { type: "application/pdf" })
     );
     window.open(url, "_blank");
+  };
+
+  const openPdfDirect = (endpoint: string) => {
+    const base = (import.meta.env.VITE_API_BASE_URL as string).replace(/\/$/, "");
+    const path = endpoint.replace(/^\//, "");
+    window.open(`${base}/${path}`, "_blank");
   };
 
   const handleExcelDownload = () => {
@@ -114,15 +122,21 @@ export default function ExportButtons({
 
     if (!pdfEndpoint) return;
 
-    const download = downloadPdf
-      ? downloadFile(pdfEndpoint, pdfFileName)
-      : openPdfInNewTab(pdfEndpoint);
-
-    promiseToast(download, {
-      loading: downloadPdf ? "Descargando PDF..." : "Abriendo PDF...",
-      success: downloadPdf ? "PDF descargado exitosamente" : "PDF abierto exitosamente",
-      error: downloadPdf ? "Error al descargar el archivo PDF" : "Error al abrir el archivo PDF",
-    });
+    if (openDirect) {
+      openPdfDirect(pdfEndpoint);
+    } else if (downloadPdf) {
+      promiseToast(downloadFile(pdfEndpoint, pdfFileName), {
+        loading: "Descargando PDF...",
+        success: "PDF descargado exitosamente",
+        error: "Error al descargar el archivo PDF",
+      });
+    } else {
+      promiseToast(openPdfInNewTab(pdfEndpoint), {
+        loading: "Abriendo PDF...",
+        success: "PDF abierto exitosamente",
+        error: "Error al abrir el archivo PDF",
+      });
+    }
   };
 
   const handleTicketDownload = () => {
@@ -137,15 +151,21 @@ export default function ExportButtons({
 
     if (!ticketEndpoint) return;
 
-    const download = downloadTicket
-      ? downloadFile(ticketEndpoint, ticketFileName)
-      : openPdfInNewTab(ticketEndpoint);
-
-    promiseToast(download, {
-      loading: downloadTicket ? "Descargando ticket..." : "Abriendo ticket...",
-      success: downloadTicket ? "Ticket descargado exitosamente" : "Ticket abierto exitosamente",
-      error: downloadTicket ? "Error al descargar el ticket" : "Error al abrir el ticket",
-    });
+    if (openDirect) {
+      openPdfDirect(ticketEndpoint);
+    } else if (downloadTicket) {
+      promiseToast(downloadFile(ticketEndpoint, ticketFileName), {
+        loading: "Descargando ticket...",
+        success: "Ticket descargado exitosamente",
+        error: "Error al descargar el ticket",
+      });
+    } else {
+      promiseToast(openPdfInNewTab(ticketEndpoint), {
+        loading: "Abriendo ticket...",
+        success: "Ticket abierto exitosamente",
+        error: "Error al abrir el ticket",
+      });
+    }
   };
 
   const showExcelButton = excelEndpoint || onExcelDownload;

--- a/src/pages/credit-note/components/CreditNoteColumns.tsx
+++ b/src/pages/credit-note/components/CreditNoteColumns.tsx
@@ -210,6 +210,7 @@ export const CreditNoteColumns = ({
               pdfEndpoint={`/credit-notes/${row.original.id}/pdf`}
               pdfFileName={`nota-credito-${row.original.document_number}.pdf`}
               variant="separate"
+              openDirect
             />
             {["ENVIADO", "ACEPTADO"].includes(
               row.original.sunat_status?.toUpperCase(),

--- a/src/pages/debit-note/components/DebitNoteColumns.tsx
+++ b/src/pages/debit-note/components/DebitNoteColumns.tsx
@@ -149,6 +149,7 @@ export const DebitNoteColumns = ({
               pdfEndpoint={`/debit-notes/${row.original.id}/pdf`}
               pdfFileName={`nota-debito-${row.original.document_number}.pdf`}
               variant="separate"
+              openDirect
             />
             {["ENVIADO", "ACEPTADO"].includes(row.original.sunat_status?.toUpperCase()) && (
               <TooltipProvider>

--- a/src/pages/guide/components/GuideColumns.tsx
+++ b/src/pages/guide/components/GuideColumns.tsx
@@ -262,6 +262,7 @@ export const GuideColumns = ({
             pdfEndpoint={`/shipping-guide-remit/${row.original.id}/pdf`}
             pdfFileName={`guia-${row.original.full_guide_number}.pdf`}
             variant="separate"
+            openDirect
           />
           {["ENVIADA", "ACEPTADA", "DECLARADA"].includes(
             row.original.status,

--- a/src/pages/order/components/OrderColumns.tsx
+++ b/src/pages/order/components/OrderColumns.tsx
@@ -180,6 +180,7 @@ export const getOrderColumns = ({
           pdfEndpoint={`/order/pdf/${row.original.id}`}
           pdfFileName={`pedido-${row.original.order_number}.pdf`}
           variant="separate"
+          openDirect
         />
         <ButtonAction
           icon={Eye}

--- a/src/pages/person/components/PersonForm.tsx
+++ b/src/pages/person/components/PersonForm.tsx
@@ -160,6 +160,10 @@ export const PersonForm = ({
           updates.business_name = result.data.business_name || "";
           fieldsSet.business_name = true;
 
+          if (result.data.address) {
+            updates.address = result.data.address;
+          }
+
           Object.keys(updates).forEach((key) => {
             form.setValue(key as keyof PersonSchema, updates[key], {
               shouldValidate: true,

--- a/src/pages/purchase-order/components/PurchaseOrderColumns.tsx
+++ b/src/pages/purchase-order/components/PurchaseOrderColumns.tsx
@@ -134,6 +134,7 @@ export const PurchaseOrderColumns = ({
             pdfEndpoint={`/purchaseorder/${row.original.id}/pdf`}
             pdfFileName={`orden-compra-${row.original.correlativo}.pdf`}
             variant="separate"
+            openDirect
           />
           <ButtonAction
             icon={Eye}

--- a/src/pages/quotation/components/QuotationColumns.tsx
+++ b/src/pages/quotation/components/QuotationColumns.tsx
@@ -159,6 +159,7 @@ export const getQuotationColumns = ({
           pdfEndpoint={`/quotation/pdf/${row.original.id}`}
           pdfFileName={`cotizacion-${row.original.quotation_number}.pdf`}
           variant="separate"
+          openDirect
         />
         <ButtonAction
           icon={Eye}

--- a/src/pages/sale/components/SaleColumns.tsx
+++ b/src/pages/sale/components/SaleColumns.tsx
@@ -416,6 +416,7 @@ export const getSaleColumns = ({
             ticketEndpoint={`/sale/${row.original.id}/ticket`}
             ticketFileName={`ticket-venta-${row.original.sequential_number}.pdf`}
             variant="separate"
+            openDirect
           />
 
           {/* XML / CDR — al lado del PDF, solo si está enviado */}


### PR DESCRIPTION
Introduce an openDirect prop to ExportButtons that opens PDF/ticket URLs directly (using VITE_API_BASE_URL) in a new tab instead of downloading or using the existing open-in-new-tab helper. Update PDF/ticket handlers to branch between direct open, download, and open-in-tab flows with appropriate toast messages. Propagate openDirect to multiple column components (credit note, debit note, guide, order, purchase order, quotation, sale) so exported documents open directly by default. Also add a small bugfix in PersonForm to populate address from the lookup result when present.