### PR TITLE
feat: estandarización de unidades y anulación de guías , bug visual

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -1,12 +1,12 @@
-import { clsx, type ClassValue } from "clsx"
-import { twMerge } from "tailwind-merge"
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs))
+  return twMerge(clsx(inputs));
 }
 
 /**
- * Trunca (sin redondear) un número a `decimals` decimales.
+ * Trunca (sin redondear) un numero a `decimals` decimales.
  * Ej: truncDecimal(1.23456789, 6) => 1.234567
  */
 export function truncDecimal(value: number, decimals = 6): number {
@@ -16,11 +16,78 @@ export function truncDecimal(value: number, decimals = 6): number {
 }
 
 /**
- * Formatea un número truncado a `decimals` decimales y devuelve string con esos decimales.
+ * Formatea un numero truncado a `decimals` decimales y devuelve string con esos decimales.
  * Usa truncDecimal internamente para evitar cualquier redondeo.
  */
 export function formatDecimalTrunc(value: number, decimals = 6): string {
   const v = truncDecimal(value, decimals);
-  // toFixed aquí no redondeará porque ya truncamos
   return v.toFixed(decimals);
+}
+
+const DECIMAL_QUANTITY_UNITS = new Set([
+  "KG",
+  "KGM",
+  "L",
+  "LT",
+  "LTR",
+  "GR",
+  "GRM",
+  "G",
+  "ML",
+]);
+
+const INTEGER_QUANTITY_UNITS = new Set(["NIU", "UND", "PZ", "PZA", "UN"]);
+
+const QUANTITY_UNIT_ALIASES: Record<string, string> = {
+  KILO: "KG",
+  KILOS: "KG",
+  KILOGRAMO: "KG",
+  KILOGRAMOS: "KG",
+  LITRO: "L",
+  LITROS: "L",
+  GRAMO: "GR",
+  GRAMOS: "GR",
+  UNIDAD: "UND",
+  UNIDADES: "UND",
+  PIEZA: "PZ",
+  PIEZAS: "PZ",
+};
+
+export function formatQuantityWithUnit(
+  quantity: number | null | undefined,
+  unit: string,
+): string {
+  const rawUnit = unit?.trim().toUpperCase() || "";
+  const normalizedUnit = QUANTITY_UNIT_ALIASES[rawUnit] ?? rawUnit;
+
+  if (quantity === null || quantity === undefined || !Number.isFinite(quantity)) {
+    return normalizedUnit ? `- ${normalizedUnit}` : "-";
+  }
+
+  if (DECIMAL_QUANTITY_UNITS.has(normalizedUnit)) {
+    return `${quantity.toFixed(2)} ${normalizedUnit}`.trim();
+  }
+
+  if (INTEGER_QUANTITY_UNITS.has(normalizedUnit)) {
+    return `${Math.round(quantity)} ${normalizedUnit}`.trim();
+  }
+
+  return `${quantity} ${normalizedUnit}`.trim();
+}
+
+export function getDetailQuantityUnit(
+  detail: unknown,
+  fallbackUnit = "NIU",
+): string {
+  const row = detail as Record<string, any>;
+  const product = row?.product as Record<string, any> | undefined;
+
+  return (
+    row?.unit ||
+    row?.unit_measure ||
+    product?.unit ||
+    product?.unit_measure ||
+    product?.unit_code ||
+    fallbackUnit
+  );
 }

--- a/src/pages/guide/components/GuideColumns.tsx
+++ b/src/pages/guide/components/GuideColumns.tsx
@@ -12,14 +12,12 @@ import {
   DropdownMenu,
   DropdownMenuContent,
   DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { ButtonAction } from "@/components/ButtonAction";
 import {
   Copy,
   Eye,
-  Pencil,
   BanknoteArrowUp,
   FileCode2,
   FileArchive,
@@ -53,7 +51,6 @@ const downloadXml = async (endpoint: string, fileName: string) => {
 };
 
 interface GuideColumnsProps {
-  onEdit: (id: number) => void;
   onDelete: (id: number) => void;
   onView: (id: number) => void;
   onChangeStatus: (id: number, status: GuideStatus) => void;
@@ -62,7 +59,6 @@ interface GuideColumnsProps {
 }
 
 export const GuideColumns = ({
-  onEdit,
   onDelete,
   onView,
   onChangeStatus,
@@ -364,14 +360,6 @@ export const GuideColumns = ({
                   Anular guía
                 </DropdownMenuItem>
               )}
-              <DropdownMenuItem
-                onClick={() => onEdit(row.original.id)}
-                disabled={isAceptado}
-              >
-                <Pencil className="h-4 w-4 mr-2 text-muted-foreground" />
-                {isAceptado ? "No se puede editar" : "Editar"}
-              </DropdownMenuItem>
-              <DropdownMenuSeparator />
               <DropdownMenuItem
                 onClick={() => onDelete(row.original.id)}
                 disabled={isAceptado}

--- a/src/pages/guide/components/GuideColumns.tsx
+++ b/src/pages/guide/components/GuideColumns.tsx
@@ -20,12 +20,12 @@ import {
   Copy,
   Eye,
   Pencil,
-  RefreshCcw,
   BanknoteArrowUp,
   FileCode2,
   FileArchive,
   MoreHorizontal,
   Trash2,
+  Ban,
 } from "lucide-react";
 
 import { ColumnActions } from "@/components/SelectActions";
@@ -33,6 +33,7 @@ import ExportButtons from "@/components/ExportButtons";
 import { api } from "@/lib/config";
 import { toast } from "sonner";
 import { parse } from "date-fns";
+import { formatQuantityWithUnit } from "@/lib/utils";
 
 const downloadXml = async (endpoint: string, fileName: string) => {
   try {
@@ -192,8 +193,17 @@ export const GuideColumns = ({
     accessorKey: "total_weight",
     header: "Peso Total",
     cell: ({ row }) => {
-      const weight = row.original.total_weight;
-      return <span className="text-xs font-mono">{weight} KG</span>;
+      const weight =
+        row.original.total_weight === null ||
+        row.original.total_weight === undefined
+          ? undefined
+          : Number(row.original.total_weight);
+
+      return (
+        <span className="text-xs font-mono">
+          {formatQuantityWithUnit(weight, "KG")}
+        </span>
+      );
     },
   },
   {
@@ -205,6 +215,7 @@ export const GuideColumns = ({
         REGISTRADA: "secondary",
         ENVIADA: "default",
         ACEPTADA: "default",
+        DECLARADA: "default",
         RECHAZADA: "destructive",
         ANULADA: "destructive",
       }[status] as "secondary" | "default" | "destructive";
@@ -342,15 +353,17 @@ export const GuideColumns = ({
                 <Copy className="h-4 w-4 mr-2 text-muted-foreground" />
                 Duplicar
               </DropdownMenuItem>
-              <DropdownMenuItem
-                onClick={() =>
-                  onChangeStatus(row.original.id, row.original.status)
-                }
-                disabled={isAceptado}
-              >
-                <RefreshCcw className="h-4 w-4 mr-2 text-muted-foreground" />
-                Cambiar Estado
-              </DropdownMenuItem>
+              {["DECLARADA", "EMITIDA"].includes(row.original.status) && (
+                <DropdownMenuItem
+                  onClick={() =>
+                    onChangeStatus(row.original.id, row.original.status)
+                  }
+                  className="text-red-600 focus:text-red-600"
+                >
+                  <Ban className="h-4 w-4 mr-2" />
+                  Anular guía
+                </DropdownMenuItem>
+              )}
               <DropdownMenuItem
                 onClick={() => onEdit(row.original.id)}
                 disabled={isAceptado}

--- a/src/pages/guide/components/GuideDetailPage.tsx
+++ b/src/pages/guide/components/GuideDetailPage.tsx
@@ -30,6 +30,7 @@ import FormWrapper from "@/components/FormWrapper";
 import FormSkeleton from "@/components/FormSkeleton";
 import TitleFormComponent from "@/components/TitleFormComponent";
 import { GroupFormSection } from "@/components/GroupFormSection";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 
 function getPersonName(person: Carrier): string {
   if (person.type_person === "JURIDICA" || !person.names) {
@@ -541,7 +542,11 @@ export default function GuideDetailPage() {
         >
           {guide.details && guide.details.length > 0 && (
             <div className="space-y-3 col-span-full">
-              {guide.details.map((detail: GuideDetailResource, index) => (
+              {guide.details.map((detail: GuideDetailResource, index) => {
+                const unit = getDetailQuantityUnit(detail, "UND");
+                const weight = Number(detail.weight);
+
+                return (
                 <div
                   key={detail.id}
                   className="p-3 bg-muted/30 rounded-lg border hover:bg-muted/50 transition-colors"
@@ -571,23 +576,19 @@ export default function GuideDetailPage() {
                         )}
                     </div>
                     <div className="text-right shrink-0 space-y-1">
-                      <div>
-                        <p className="font-bold text-2xl text-primary">
-                          {detail.quantity}
-                        </p>
-                        <Badge variant="secondary" className="mt-0.5">
-                          {detail.unit || detail.unit_measure || "UND"}
-                        </Badge>
-                      </div>
-                      {detail.weight && (
+                      <p className="font-bold text-2xl text-primary">
+                        {formatQuantityWithUnit(Number(detail.quantity), unit)}
+                      </p>
+                      {Number.isFinite(weight) && weight > 0 && (
                         <p className="text-xs text-muted-foreground">
-                          {detail.weight} kg
+                          {formatQuantityWithUnit(weight, "KG")}
                         </p>
                       )}
                     </div>
                   </div>
                 </div>
-              ))}
+                );
+              })}
             </div>
           )}
 

--- a/src/pages/guide/components/GuidePage.tsx
+++ b/src/pages/guide/components/GuidePage.tsx
@@ -23,7 +23,6 @@ import {
 } from "../lib/guide.interface";
 import { DEFAULT_PER_PAGE } from "@/lib/core.constants";
 import { useSidebar } from "@/components/ui/sidebar";
-
 const { MODEL, ICON } = GUIDE;
 
 export default function GuidePage() {
@@ -71,6 +70,13 @@ export default function GuidePage() {
   };
 
   const handleChangeStatus = (id: number, currentStatus: GuideStatus) => {
+    if (!["DECLARADA", "EMITIDA"].includes(currentStatus)) {
+      errorToast(
+        "Solo se puede anular una guía con estado DECLARADA o EMITIDA",
+        "Acción no disponible",
+      );
+      return;
+    }
     setStatusChangeData({ id, currentStatus });
   };
 
@@ -87,7 +93,7 @@ export default function GuidePage() {
     try {
       await changeStatus(statusChangeData.id, newStatus);
       await refetch();
-      successToast(`Estado actualizado a ${newStatus}`);
+      successToast("Guía anulada correctamente");
     } catch (error: any) {
       errorToast(
         error.response?.data?.message || "Error al actualizar el estado",

--- a/src/pages/guide/components/GuidePage.tsx
+++ b/src/pages/guide/components/GuidePage.tsx
@@ -48,10 +48,6 @@ export default function GuidePage() {
     setOpenMobile(true);
   }, []);
 
-  const handleEdit = (id: number) => {
-    navigate(`${GUIDE.ROUTE}/actualizar/${id}`);
-  };
-
   const handleView = (id: number) => {
     navigate(`${GUIDE.ROUTE}/${id}`);
   };
@@ -128,7 +124,6 @@ export default function GuidePage() {
       <GuideTable
         isLoading={isLoading}
         columns={GuideColumns({
-          onEdit: handleEdit,
           onDelete: setDeleteId,
           onView: handleView,
           onChangeStatus: handleChangeStatus,

--- a/src/pages/guide/components/GuideStatusChangeDialog.tsx
+++ b/src/pages/guide/components/GuideStatusChangeDialog.tsx
@@ -1,5 +1,3 @@
-"use client";
-
 import { useState } from "react";
 import {
   Dialog,
@@ -9,14 +7,7 @@ import {
   DialogDescription,
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { GUIDE_STATUSES, type GuideStatus } from "../lib/guide.interface";
+import { GUIDE_STATUS_LABELS, type GuideStatus } from "../lib/guide.interface";
 
 interface GuideStatusChangeDialogProps {
   onConfirm: (newStatus: GuideStatus) => Promise<void>;
@@ -32,56 +23,35 @@ export function GuideStatusChangeDialog({
   currentStatus,
 }: GuideStatusChangeDialogProps) {
   const [loading, setLoading] = useState(false);
-  const [selectedStatus, setSelectedStatus] =
-    useState<GuideStatus>(currentStatus);
+  const currentStatusLabel = GUIDE_STATUS_LABELS[currentStatus] ?? currentStatus;
+  const canAnnul = ["DECLARADA", "EMITIDA"].includes(currentStatus);
 
   const handleConfirm = async () => {
-    if (selectedStatus === currentStatus) {
-      onOpenChange(false);
-      return;
-    }
+    if (!canAnnul) return;
 
     setLoading(true);
     try {
-      await onConfirm(selectedStatus);
+      await onConfirm("ANULADA");
       onOpenChange(false);
     } finally {
       setLoading(false);
     }
   };
 
-  const currentStatusLabel = GUIDE_STATUSES.find(
-    (s) => s.value === currentStatus
-  )?.label;
-
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent>
         <DialogHeader>
-          <DialogTitle>Cambiar estado de guía de remisión</DialogTitle>
+          <DialogTitle>Anular guía de remisión</DialogTitle>
           <DialogDescription>
             Estado actual: <strong>{currentStatusLabel}</strong>
           </DialogDescription>
         </DialogHeader>
         <div className="space-y-4">
-          <div className="space-y-2 w-full">
-            <label className="text-sm font-medium">Nuevo estado</label>
-            <Select
-              value={selectedStatus}
-              onValueChange={(value) => setSelectedStatus(value as GuideStatus)}
-            >
-              <SelectTrigger className="w-full">
-                <SelectValue />
-              </SelectTrigger>
-              <SelectContent>
-                {GUIDE_STATUSES.map((status) => (
-                  <SelectItem key={status.value} value={status.value}>
-                    {status.label}
-                  </SelectItem>
-                ))}
-              </SelectContent>
-            </Select>
-          </div>
+          <p className="text-sm text-muted-foreground">
+            Esta acción cambiará el estado de la guía a <strong>ANULADA</strong>.
+            Solo aplica para guías declaradas o emitidas.
+          </p>
           <div className="flex justify-end gap-2">
             <Button
               variant="outline"
@@ -91,11 +61,11 @@ export function GuideStatusChangeDialog({
               Cancelar
             </Button>
             <Button
-              variant="default"
+              variant="destructive"
               onClick={handleConfirm}
-              disabled={loading || selectedStatus === currentStatus}
+              disabled={loading || !canAnnul}
             >
-              {loading ? "Actualizando..." : "Confirmar"}
+              {loading ? "Anulando..." : "Anular"}
             </Button>
           </div>
         </div>

--- a/src/pages/guide/lib/guide.actions.ts
+++ b/src/pages/guide/lib/guide.actions.ts
@@ -73,14 +73,14 @@ export const deleteGuide = async (id: number): Promise<{ message: string }> => {
 };
 
 export interface ChangeGuideStatusRequest {
-  status: string; // "EMITIDA" | "EN_TRANSITO" | "ENTREGADA" | "ANULADA"
+  status: "ANULADA";
 }
 
 export const changeGuideStatus = async (
   id: number,
   data: ChangeGuideStatusRequest,
 ): Promise<{ message: string }> => {
-  const response = await api.patch<{ message: string }>(
+  const response = await api.put<{ message: string }>(
     `${GUIDE_ENDPOINT}/${id}/status`,
     data,
   );

--- a/src/pages/guide/lib/guide.interface.ts
+++ b/src/pages/guide/lib/guide.interface.ts
@@ -10,7 +10,12 @@ export interface GuideMotiveResource {
   name: string;
 }
 
-export type GuideStatus = "EMITIDA" | "EN_TRANSITO" | "ENTREGADA" | "ANULADA";
+export type GuideStatus =
+  | "EMITIDA"
+  | "EN_TRANSITO"
+  | "ENTREGADA"
+  | "DECLARADA"
+  | "ANULADA";
 
 export interface GuideResourceById {
   data: GuideResource;
@@ -214,6 +219,7 @@ export const GUIDE_STATUSES = [
   { value: "EMITIDA", label: "Emitida" },
   { value: "EN_TRANSITO", label: "En tránsito" },
   { value: "ENTREGADA", label: "Entregada" },
+  { value: "DECLARADA", label: "Declarada" },
   { value: "ANULADA", label: "Anulada" },
 ] as const;
 
@@ -221,6 +227,7 @@ export const GUIDE_STATUS_LABELS: Record<GuideStatus, string> = {
   EMITIDA: "Emitida",
   EN_TRANSITO: "En tránsito",
   ENTREGADA: "Entregada",
+  DECLARADA: "Declarada",
   ANULADA: "Anulada",
 };
 

--- a/src/pages/guide/lib/guide.store.ts
+++ b/src/pages/guide/lib/guide.store.ts
@@ -4,6 +4,7 @@ import type {
   GuideMotiveResource,
   CreateGuideRequest,
   UpdateGuideRequest,
+  GuideStatus,
 } from "./guide.interface";
 import {
   getGuides,
@@ -45,7 +46,7 @@ interface GuideStore {
   createGuide: (data: GuideSchema) => Promise<void>;
   updateGuide: (id: number, data: Partial<GuideSchema>) => Promise<void>;
   removeGuide: (id: number) => Promise<void>;
-  changeStatus: (id: number, status: string) => Promise<void>;
+  changeStatus: (id: number, status: GuideStatus) => Promise<void>;
   resetGuide: () => void;
 }
 
@@ -320,9 +321,12 @@ export const useGuideStore = create<GuideStore>((set) => ({
   },
 
   // Change guide status
-  changeStatus: async (id: number, status: string) => {
+  changeStatus: async (id: number, status: GuideStatus) => {
     set({ isSubmitting: true, error: null });
     try {
+      if (status !== "ANULADA") {
+        throw new Error("Solo se permite anular la guía");
+      }
       await changeGuideStatus(id, { status });
       set({ isSubmitting: false });
     } catch (error) {

--- a/src/pages/order/components/OrderDetailPage.tsx
+++ b/src/pages/order/components/OrderDetailPage.tsx
@@ -32,6 +32,7 @@ import FormWrapper from "@/components/FormWrapper";
 import { ORDER } from "../lib/order.interface";
 import FormSkeleton from "@/components/FormSkeleton";
 import TitleFormComponent from "@/components/TitleFormComponent";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 
 const statusVariant: Record<string, "yellow" | "blue" | "green" | "red" | "gray" | "default" | "secondary"> = {
   Pendiente: "yellow",
@@ -218,7 +219,10 @@ export default function OrderDetailPage() {
                           <p className="font-medium text-sm">{detail.product.name}</p>
                         </TableCell>
                         <TableCell className="text-right tabular-nums text-sm">
-                          {Number(detail.quantity).toFixed(2)}
+                          {formatQuantityWithUnit(
+                            Number(detail.quantity),
+                            getDetailQuantityUnit(detail),
+                          )}
                         </TableCell>
                         <TableCell className="text-right tabular-nums text-sm text-muted-foreground">
                           {currency} {Number(detail.unit_price).toFixed(2)}

--- a/src/pages/order/components/OrderForm.tsx
+++ b/src/pages/order/components/OrderForm.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { roundTo4, roundTo8 } from "@/lib/saleCalculations";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -678,7 +679,10 @@ export const OrderForm = ({
                       <TableCell>{index + 1}</TableCell>
                       <TableCell>{detail.product_name}</TableCell>
                       <TableCell className="text-right">
-                        {parseFloat(detail.quantity).toFixed(4)}
+                        {formatQuantityWithUnit(
+                          Number(detail.quantity),
+                          getDetailQuantityUnit(detail),
+                        )}
                       </TableCell>
                       <TableCell className="text-right">
                         {(getDisplayPriceIgv(detail) / 1.18).toFixed(4)}

--- a/src/pages/order/components/OrderSummary.tsx
+++ b/src/pages/order/components/OrderSummary.tsx
@@ -7,6 +7,7 @@ import type { PersonResource } from "@/pages/person/lib/person.interface";
 import type { WarehouseResource } from "@/pages/warehouse/lib/warehouse.interface";
 import { formatNumber } from "@/lib/formatCurrency";
 import type { UseFormReturn } from "react-hook-form";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 
 interface DetailRow {
   product_id: string;
@@ -177,7 +178,11 @@ export function OrderSummary({
                         {detail.product_name}
                       </p>
                       <p className="text-xs text-muted-foreground">
-                        {detail.quantity} x {currencySymbol}{" "}
+                        {formatQuantityWithUnit(
+                          Number(detail.quantity),
+                          getDetailQuantityUnit(detail),
+                        )}{" "}
+                        x {currencySymbol}{" "}
                         {parseFloat(detail.unit_price).toLocaleString("es-PE", {
                           minimumFractionDigits: 2,
                         })}

--- a/src/pages/quotation/components/AddProductSheet.tsx
+++ b/src/pages/quotation/components/AddProductSheet.tsx
@@ -142,6 +142,9 @@
     useEffect(() => {
       if (open) {
         setLastSetPrice(null);
+        setSelectedProduct(null);
+        setShowHistory(false);
+        setShowStock(false);
 
         if (editingDetail) {
           // unit_price_igv siempre es el precio CON IGV
@@ -160,7 +163,7 @@
             price_category_id: "",
             is_igv: editingDetail.is_igv,
             convert_currency: false,
-            quantity: editingDetail.quantity,
+            quantity: Number(editingDetail.quantity).toString(),
             unit_value: unitValueField,
             unit_price: unitPriceField,
             purchase_price: editingDetail.purchase_price ?? "0",
@@ -229,7 +232,11 @@
         return;
       }
 
-      const productName = selectedProduct?.name ?? editingDetail?.product_name;
+      const selectedProductMatches =
+        selectedProduct?.id?.toString() === formData.product_id;
+      const productName = selectedProductMatches
+        ? selectedProduct.name
+        : editingDetail?.product_name;
       if (!productName) return;
       const typedUnitPrice = parseFloat(String(formData.unit_price)) || 0;
       let finalPriceIgv = typedUnitPrice;
@@ -249,7 +256,7 @@
         product_id: formData.product_id,
         product_name: productName,
         is_igv: formData.is_igv,
-        quantity: formData.quantity,
+        quantity: Number(formData.quantity).toString(),
         unit_price: sentUnitPrice,
         unit_price_igv: sentUnitPriceIgv,
         purchase_price: formData.purchase_price ?? "0",
@@ -262,6 +269,7 @@
 
       if (isEditMode && onEdit && editIndex !== null) {
         onEdit(detail, editIndex);
+        setSelectedProduct(null);
         onClose();
       } else {
         onAdd(detail);

--- a/src/pages/quotation/components/QuotationDetailPage.tsx
+++ b/src/pages/quotation/components/QuotationDetailPage.tsx
@@ -34,6 +34,7 @@ import FormWrapper from "@/components/FormWrapper";
 import { QUOTATION } from "../lib/quotation.interface";
 import FormSkeleton from "@/components/FormSkeleton";
 import TitleFormComponent from "@/components/TitleFormComponent";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 
 const statusVariant: Record<string, "yellow" | "green" | "red" | "gray" | "default" | "secondary"> = {
   Pendiente: "yellow",
@@ -227,17 +228,20 @@ export default function QuotationDetailPage() {
                           )}
                         </TableCell>
                         <TableCell className="text-right tabular-nums text-sm">
-                          {Number(detail.quantity).toFixed(2)}
+                          {formatQuantityWithUnit(
+                            Number(detail.quantity),
+                            getDetailQuantityUnit(detail),
+                          )}
                         </TableCell>
                         <TableCell className="text-right tabular-nums text-sm text-muted-foreground">
                           {currency} {Number(detail.unit_price).toFixed(2)}
                         </TableCell>
                         <TableCell className="text-center">
                           <Badge
-                            variant={!!detail.is_igv ? "default" : "secondary"}
+                            variant={detail.is_igv ? "default" : "secondary"}
                             className="text-xs"
                           >
-                            {!!detail.is_igv ? "Incluido" : "No"}
+                            {detail.is_igv ? "Incluido" : "No"}
                           </Badge>
                         </TableCell>
                         <TableCell className="text-right tabular-nums text-sm text-muted-foreground">

--- a/src/pages/quotation/components/QuotationForm.tsx
+++ b/src/pages/quotation/components/QuotationForm.tsx
@@ -12,6 +12,7 @@ import {
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
 import { roundTo4, roundTo8 } from "@/lib/saleCalculations";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
 import {
@@ -278,7 +279,10 @@ export const QuotationForm = ({
         header: "Cantidad",
         cell: ({ row }) => (
           <div className="text-right">
-            {parseFloat(row.original.quantity).toFixed(4)}
+            {formatQuantityWithUnit(
+              Number(row.original.quantity),
+              getDetailQuantityUnit(row.original),
+            )}
           </div>
         ),
       },
@@ -437,23 +441,26 @@ export const QuotationForm = ({
   };
 
   const handleUpdateDetail = (detail: ProductDetail, index: number) => {
-    const updatedDetail: DetailRow = {
-      product_id: detail.product_id,
-      product_name: detail.product_name,
-      is_igv: detail.is_igv,
-      quantity: detail.quantity,
-      unit_price: detail.unit_price,
-      unit_price_igv: detail.unit_price_igv,
-      purchase_price: detail.purchase_price,
-      description: detail.description || "",
-      subtotal: detail.subtotal,
-      tax: detail.tax,
-      total: detail.total,
-    };
+    setDetails((prevDetails) =>
+      prevDetails.map((item, currentIndex) => {
+        if (currentIndex !== index) return item;
 
-    const updatedDetails = [...details];
-    updatedDetails[index] = updatedDetail;
-    setDetails(updatedDetails);
+        return {
+          ...item,
+          product_id: detail.product_id || item.product_id,
+          product_name: detail.product_name || item.product_name,
+          is_igv: detail.is_igv,
+          quantity: detail.quantity,
+          unit_price: detail.unit_price,
+          unit_price_igv: detail.unit_price_igv,
+          purchase_price: detail.purchase_price,
+          description: detail.description || "",
+          subtotal: detail.subtotal,
+          tax: detail.tax,
+          total: detail.total,
+        };
+      }),
+    );
     setEditingDetail(null);
     setEditingIndex(null);
   };

--- a/src/pages/quotation/components/QuotationSummary.tsx
+++ b/src/pages/quotation/components/QuotationSummary.tsx
@@ -7,6 +7,7 @@ import type { WarehouseResource } from "@/pages/warehouse/lib/warehouse.interfac
 import { formatNumber } from "@/lib/formatCurrency";
 import type { UseFormReturn } from "react-hook-form";
 import type { PersonResource } from "@/pages/person/lib/person.interface";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 
 interface DetailRow {
   product_id: string;
@@ -179,7 +180,11 @@ export function QuotationSummary({
                         {detail.product_name}
                       </p>
                       <p className="text-xs text-muted-foreground">
-                        {detail.quantity} x {currencySymbol}{" "}
+                        {formatQuantityWithUnit(
+                          Number(detail.quantity),
+                          getDetailQuantityUnit(detail),
+                        )}{" "}
+                        x {currencySymbol}{" "}
                         {parseFloat(detail.unit_price).toLocaleString("es-PE", {
                           minimumFractionDigits: 2,
                         })}

--- a/src/pages/sale/components/SaleDetailSheet.tsx
+++ b/src/pages/sale/components/SaleDetailSheet.tsx
@@ -19,6 +19,7 @@ import {
 } from "lucide-react";
 import type { SaleResource } from "../lib/sale.interface";
 import TraceabilityTimeline from "@/components/TraceabilityTimeline";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 
 interface SaleDetailSheetProps {
   sale: SaleResource | null;
@@ -342,7 +343,11 @@ export default function SaleDetailSheet({ sale, open, onClose }: SaleDetailSheet
                         <p className="text-sm font-medium leading-snug">{detail.product.name}</p>
                       </div>
                       <p className="text-xs text-muted-foreground mt-0.5 ml-4">
-                        {Number(detail.quantity).toFixed(2)} × {currency} {Number(detail.unit_price).toFixed(2)}
+                        {formatQuantityWithUnit(
+                          Number(detail.quantity),
+                          getDetailQuantityUnit(detail),
+                        )}{" "}
+                        × {currency} {Number(detail.unit_price).toFixed(2)}
                       </p>
                     </div>
                     <div className="text-right shrink-0">

--- a/src/pages/sale/components/SaleForm.tsx
+++ b/src/pages/sale/components/SaleForm.tsx
@@ -41,6 +41,7 @@ import { useProductPrices } from "@/pages/product/lib/product-price.hook";
 import { ClientCreateModal } from "@/pages/client/components/ClientCreateModal";
 import { WarehouseCreateModal } from "@/pages/warehouse/components/WarehouseCreateModal";
 import { formatNumber } from "@/lib/formatCurrency";
+import { formatQuantityWithUnit, getDetailQuantityUnit } from "@/lib/utils";
 import {
   roundTo8,
   roundTo4,
@@ -1583,7 +1584,10 @@ export const SaleForm = ({
                         <TableCell>{index + 1}</TableCell>
                         <TableCell>{detail.product_name}</TableCell>
                         <TableCell className="text-right">
-                          {formatNumber(parseFloat(detail.quantity), 4)}
+                          {formatQuantityWithUnit(
+                            Number(detail.quantity),
+                            getDetailQuantityUnit(detail),
+                          )}
                         </TableCell>
                         <TableCell className="text-right">
                           {formatNumber(parseFloat(detail.unit_price), 4)}


### PR DESCRIPTION
Pase a producción (main) con los requerimientos aprobados del acta:
Guías: Se agregó la funcionalidad para anular guías manualmente (Punto 4).
Guías: Se eliminó el botón de "Editar" en el listado para respetar el flujo directo al facturador.
Unidades: Se estandarizó la visualización de cantidades en todos los documentos impresos y vistas de Cotizaciones, Pedidos, Guías y Ventas (Punto 6).
Corrección de Bugs:
Fix: Se solucionó la sobreescritura del nombre del producto al editar en el modal de cotizaciones.
Fix: Se limpió el bug visual de los decimales infinitos en los inputs al cargar un producto para edición.