### PR TITLE
Add product weight and item history views

### DIFF
--- a/src/pages/product/components/ProductAddPage.tsx
+++ b/src/pages/product/components/ProductAddPage.tsx
@@ -36,6 +36,7 @@ export default function ProductAddPage() {
     unit_id: "",
     product_type_id: "",
     is_igv: false,
+    weight: 0,
     observations: "",
     technical_sheet: [],
   });

--- a/src/pages/product/components/ProductColumns.tsx
+++ b/src/pages/product/components/ProductColumns.tsx
@@ -71,6 +71,18 @@ export const ProductColumns = ({
     cell: ({ getValue }) => getValue() as string,
   },
   {
+    accessorKey: "weight",
+    header: "Peso",
+    cell: ({ getValue }) => {
+      const weight = getValue() as number | null;
+      return weight != null ? (
+        <span className="text-sm">{weight} kg</span>
+      ) : (
+        <span className="text-sm text-muted-foreground">-</span>
+      );
+    },
+  },
+  {
     accessorKey: "product_type_name",
     header: "Tipo",
     cell: ({ getValue }) => {

--- a/src/pages/product/components/ProductEditPage.tsx
+++ b/src/pages/product/components/ProductEditPage.tsx
@@ -46,6 +46,7 @@ export default function ProductEditPage() {
     unit_id: data.unit_id?.toString(),
     product_type_id: data.product_type_id?.toString(),
     is_igv: Boolean((data as any).is_igv) || false,
+    weight: Number((data as any).weight) || 0,
     observations: (data as any).observations || "",
     technical_sheet: [],
   });

--- a/src/pages/product/components/ProductForm.tsx
+++ b/src/pages/product/components/ProductForm.tsx
@@ -13,6 +13,7 @@ import {
 import { Input } from "@/components/ui/input";
 import { Button } from "@/components/ui/button";
 import { Textarea } from "@/components/ui/textarea";
+import { FormInput } from "@/components/FormInput";
 import {
   productSchemaCreate,
   productSchemaUpdate,
@@ -197,6 +198,7 @@ export const ProductForm = ({
                 mapOptionFn={(productType: ProductTypeResource) => ({
                   value: productType.id.toString(),
                   label: productType.name,
+                  description: productType.code,
                 })}
               />
             </div>
@@ -256,6 +258,15 @@ export const ProductForm = ({
               <Plus className="h-4 w-4" />
             </Button>
           </div>
+
+          <FormInput
+            control={form.control}
+            name="weight"
+            label="Peso"
+            placeholder="Ingrese el peso"
+            type="number"
+            step="0.001"
+          />
 
           <FormSwitch
             control={form.control}

--- a/src/pages/product/lib/product.interface.ts
+++ b/src/pages/product/lib/product.interface.ts
@@ -41,6 +41,7 @@ export const PRODUCT: ModelComplete<ProductSchema> = {
     unit_id: "",
     product_type_id: "",
     is_igv: false,
+    weight: 0,
     observations: "",
     technical_sheet: [],
   },
@@ -63,6 +64,7 @@ export interface ProductResource {
   unit_name: string;
   observations?: string;
   is_igv: number;
+  weight: number | null;
   technical_sheet?: string[];
   product_images: string[];
   components: Component[];

--- a/src/pages/product/lib/product.schema.ts
+++ b/src/pages/product/lib/product.schema.ts
@@ -11,6 +11,10 @@ export const productSchemaCreate = z.object({
   unit_id: requiredStringId("Debe seleccionar una unidad"),
   product_type_id: requiredStringId("Debe seleccionar un tipo de producto"),
   is_igv: z.boolean().default(false),
+  weight: z.coerce
+    .number()
+    .min(0, { message: "El peso debe ser mayor o igual a 0" })
+    .default(0),
   observations: z.string().optional().default(""),
   technical_sheet: z.array(z.instanceof(File)).optional().default([]),
 });

--- a/src/pages/product/lib/product.store.ts
+++ b/src/pages/product/lib/product.store.ts
@@ -41,6 +41,7 @@ const createFormData = (data: ProductSchema): FormData => {
 
   formData.append("name", data.name);
   formData.append("is_igv", data.is_igv ? "1" : "0");
+  formData.append("weight", (data.weight ?? 0).toString());
 
   if(data.category_id){
       formData.append("category_id", data.category_id.toString());

--- a/src/pages/production-document/components/ProductionDocumentAddPage.tsx
+++ b/src/pages/production-document/components/ProductionDocumentAddPage.tsx
@@ -1,80 +1,39 @@
 import { useNavigate, useLocation } from "react-router-dom";
-import { useEffect, useState } from "react";
 import { useProductionDocumentStore } from "../lib/production-document.store";
 import {
   ERROR_MESSAGE,
-  SUCCESS_MESSAGE,
   errorToast,
   successToast,
 } from "@/lib/core.function";
 import { PRODUCTION_DOCUMENT } from "../lib/production-document.interface";
-import {
-  ProductionDocumentForm,
-  type ProductionDocumentFormValues,
-} from "./ProductionDocumentForm";
+import type { CreateProductionDocumentBatchRequest } from "../lib/production-document.interface";
+import { ProductionDocumentBatchForm } from "./ProductionDocumentBatchForm";
 import { useAllWarehouses } from "@/pages/warehouse/lib/warehouse.hook";
 import PageSkeleton from "@/components/PageSkeleton";
-import { findProductionOrderById } from "@/pages/production-order/lib/production-order.actions";
-import { useAuthStore } from "@/pages/auth/lib/auth.store";
 
 export default function ProductionDocumentAddPage() {
   const { ROUTE, MODEL } = PRODUCTION_DOCUMENT;
   const navigate = useNavigate();
   const location = useLocation();
-  const { user } = useAuthStore();
-  const { createDocument, isSubmitting } = useProductionDocumentStore();
+  const { createDocumentBatch, isSubmitting } = useProductionDocumentStore();
 
   const fromOrderId: number | undefined = location.state?.fromOrderId;
-
-  const [loadingOrder, setLoadingOrder] = useState(false);
-  const [orderInitialValues, setOrderInitialValues] =
-    useState<ProductionDocumentFormValues | null>(null);
 
   const { data: warehouses = [], isLoading: loadingWarehouses } =
     useAllWarehouses();
 
-  useEffect(() => {
-    if (!fromOrderId) return;
-    setLoadingOrder(true);
-    findProductionOrderById(fromOrderId)
-      .then((response) => {
-        const order = response.data.data;
-        setOrderInitialValues({
-          warehouse_origin_id: order.warehouse_origin_id.toString(),
-          warehouse_dest_id: order.warehouse_dest_id.toString(),
-          product_id: order.product_id ? order.product_id.toString() : "",
-          user_id: user?.id.toString() || "",
-          responsible_id: order.responsible_id.toString(),
-          production_order_id: order.id.toString(),
-          production_date: "",
-          quantity_produced: order.quantity_requested.toString(),
-          labor_cost: order.labor_cost.toString(),
-          overhead_cost: "",
-          observations: order.observations || "",
-          components: (order.components ?? []).map((c) => ({
-            component_id: c.component_id.toString(),
-            component_name: c.component.name,
-            quantity_required: c.quantity_required.toString(),
-            quantity_used: c.quantity_required.toString(),
-            unit_cost: c.unit_cost.toString(),
-            notes: c.notes || "",
-          })),
-        });
-      })
-      .catch(() => {
-        errorToast("Error al cargar los datos de la orden de producción");
-      })
-      .finally(() => {
-        setLoadingOrder(false);
-      });
-  }, [fromOrderId, user?.id]);
-
-  const isLoading = loadingWarehouses || loadingOrder;
-
-  const onSubmit = async (values: ProductionDocumentFormValues) => {
+  // ✅ Toda orden agrupa uno o varios productos (items[]); generar un
+  // documento "desde una orden" significa elegir cuáles de esos productos se
+  // producen ahora. El backend expone /productiondocument/batch para crear,
+  // en una sola request, un documento independiente por cada ítem elegido.
+  const onSubmit = async (payload: CreateProductionDocumentBatchRequest) => {
     try {
-      await createDocument(values as any);
-      successToast(SUCCESS_MESSAGE(MODEL, "create"));
+      const created = await createDocumentBatch(payload);
+      successToast(
+        created.length > 1
+          ? `${created.length} documentos de producción generados correctamente`
+          : "Documento de producción generado correctamente",
+      );
       navigate(ROUTE);
     } catch (error: any) {
       errorToast(
@@ -83,17 +42,16 @@ export default function ProductionDocumentAddPage() {
     }
   };
 
-  if (isLoading) {
+  if (loadingWarehouses) {
     return <PageSkeleton />;
   }
 
   return (
-    <ProductionDocumentForm
-      mode="create"
+    <ProductionDocumentBatchForm
       onSubmit={onSubmit}
       isSubmitting={isSubmitting}
       warehouses={warehouses || []}
-      initialValues={orderInitialValues ?? undefined}
+      fromOrderId={fromOrderId}
     />
   );
 }

--- a/src/pages/production-document/components/ProductionDocumentAddPage.tsx
+++ b/src/pages/production-document/components/ProductionDocumentAddPage.tsx
@@ -42,7 +42,7 @@ export default function ProductionDocumentAddPage() {
         setOrderInitialValues({
           warehouse_origin_id: order.warehouse_origin_id.toString(),
           warehouse_dest_id: order.warehouse_dest_id.toString(),
-          product_id: order.product_id.toString(),
+          product_id: order.product_id ? order.product_id.toString() : "",
           user_id: user?.id.toString() || "",
           responsible_id: order.responsible_id.toString(),
           production_order_id: order.id.toString(),
@@ -51,7 +51,7 @@ export default function ProductionDocumentAddPage() {
           labor_cost: order.labor_cost.toString(),
           overhead_cost: "",
           observations: order.observations || "",
-          components: order.components.map((c) => ({
+          components: (order.components ?? []).map((c) => ({
             component_id: c.component_id.toString(),
             component_name: c.component.name,
             quantity_required: c.quantity_required.toString(),

--- a/src/pages/production-document/components/ProductionDocumentBatchForm.tsx
+++ b/src/pages/production-document/components/ProductionDocumentBatchForm.tsx
@@ -1,0 +1,530 @@
+import { useEffect, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { useForm } from "react-hook-form";
+import type { ColumnDef } from "@tanstack/react-table";
+import TitleFormComponent from "@/components/TitleFormComponent";
+import FormWrapper from "@/components/FormWrapper";
+import { PRODUCTION_DOCUMENT } from "../lib/production-document.interface";
+import type {
+  CreateProductionDocumentBatchRequest,
+  CreateProductionDocumentBatchItemRequest,
+} from "../lib/production-document.interface";
+import { Button } from "@/components/ui/button";
+import { Form } from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
+import {
+  Loader,
+  Factory,
+  ClipboardList,
+  Package,
+  AlertTriangle,
+  CheckCircle2,
+} from "lucide-react";
+import { FormSelect } from "@/components/FormSelect";
+import { FormSelectAsync } from "@/components/FormSelectAsync";
+import { DatePickerFormField } from "@/components/DatePickerFormField";
+import { GroupFormSection } from "@/components/GroupFormSection";
+import { DataTable } from "@/components/DataTable";
+import { toast } from "sonner";
+import type { WarehouseResource } from "@/pages/warehouse/lib/warehouse.interface";
+import type { PersonResource } from "@/pages/person/lib/person.interface";
+import { useWorkers } from "@/pages/worker/lib/worker.hook";
+import { getAllWarehouseProducts } from "@/pages/warehouse-product/lib/warehouse-product.actions";
+import {
+  useProductionOrdersSearch,
+  useProductionOrderById,
+} from "@/pages/production-order/lib/production-order.hook";
+import type {
+  ProductionOrderResource,
+  ProductionOrderComponentResource,
+} from "@/pages/production-order/lib/production-order.interface";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+
+// Fila de UI por cada ítem de la orden: una orden con varios productos genera
+// N documentos independientes (uno por ítem marcado), todos en una sola
+// request a POST /productiondocument/batch.
+type BatchItemRow = {
+  production_order_item_id: number;
+  product_name: string;
+  quantity_pending: number;
+  status: string;
+  selected: boolean;
+  quantity_produced: string;
+  labor_cost: string;
+  overhead_cost: string;
+  observations: string;
+  components: ProductionOrderComponentResource[];
+};
+
+type GlobalFormValues = {
+  production_order_id: string;
+  warehouse_origin_id: string;
+  warehouse_dest_id: string;
+  production_date: string;
+  responsible_id: string;
+};
+
+interface ProductionDocumentBatchFormProps {
+  warehouses: WarehouseResource[];
+  fromOrderId?: number;
+  isSubmitting?: boolean;
+  onSubmit: (payload: CreateProductionDocumentBatchRequest) => Promise<void> | void;
+}
+
+const componentColumns: ColumnDef<ProductionOrderComponentResource>[] = [
+  {
+    accessorKey: "component",
+    header: "Componente",
+    cell: ({ row }) => <span>{row.original.component.name}</span>,
+  },
+  {
+    accessorKey: "quantity_required",
+    header: "Cant. Requerida",
+    cell: ({ row }) => <span>{row.original.quantity_required}</span>,
+  },
+  {
+    accessorKey: "unit_cost",
+    header: "Costo Unit.",
+    cell: ({ row }) => <span>S/ {row.original.unit_cost.toFixed(2)}</span>,
+  },
+];
+
+export function ProductionDocumentBatchForm({
+  warehouses,
+  fromOrderId,
+  isSubmitting = false,
+  onSubmit,
+}: ProductionDocumentBatchFormProps) {
+  const { ROUTE, MODEL, ICON } = PRODUCTION_DOCUMENT;
+  const navigate = useNavigate();
+
+  const today = new Date();
+  const todayStr = today.toISOString().split("T")[0];
+
+  const form = useForm<GlobalFormValues>({
+    defaultValues: {
+      production_order_id: fromOrderId ? fromOrderId.toString() : "",
+      warehouse_origin_id: "",
+      warehouse_dest_id: "",
+      production_date: todayStr,
+      responsible_id: "",
+    },
+  });
+
+  const productionOrderId = form.watch("production_order_id");
+  const warehouseOriginId = form.watch("warehouse_origin_id");
+  const warehouseDestId = form.watch("warehouse_dest_id");
+
+  const { data: order, isLoading: loadingOrder } = useProductionOrderById(
+    Number(productionOrderId) || 0,
+  );
+
+  const [items, setItems] = useState<BatchItemRow[]>([]);
+
+  // Al cargar (o cambiar de) orden, se reconstruyen las filas de ítems y se
+  // rellenan los campos generales con los valores por defecto de la orden.
+  useEffect(() => {
+    if (!order) {
+      setItems([]);
+      return;
+    }
+    form.setValue("warehouse_origin_id", order.warehouse_origin_id.toString());
+    form.setValue("warehouse_dest_id", order.warehouse_dest_id.toString());
+    form.setValue("responsible_id", order.responsible_id.toString());
+    setItems(
+      order.items.map((item) => ({
+        production_order_item_id: item.id,
+        product_name: item.product.name,
+        quantity_pending: item.quantity_pending,
+        status: item.status,
+        selected: item.quantity_pending > 0,
+        quantity_produced: item.quantity_pending > 0 ? item.quantity_pending.toString() : "0",
+        labor_cost: item.labor_cost.toString(),
+        overhead_cost: item.overhead_cost.toString(),
+        observations: "",
+        components: item.components || [],
+      })),
+    );
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [order]);
+
+  const updateItem = (index: number, patch: Partial<BatchItemRow>) => {
+    setItems((prev) => prev.map((it, i) => (i === index ? { ...it, ...patch } : it)));
+  };
+
+  type StockCheckResult = {
+    component_name: string;
+    component_id: number;
+    quantity_needed: number;
+    stock_available: number;
+    sufficient: boolean;
+  };
+  const [stockResults, setStockResults] = useState<StockCheckResult[]>([]);
+  const [showStockDialog, setShowStockDialog] = useState(false);
+  const [pendingPayload, setPendingPayload] = useState<CreateProductionDocumentBatchRequest | null>(null);
+  const [checkingStock, setCheckingStock] = useState(false);
+
+  const buildPayload = (values: GlobalFormValues): CreateProductionDocumentBatchRequest | null => {
+    const selectedItems = items.filter((it) => it.selected);
+    if (selectedItems.length === 0) {
+      toast.error("Debe seleccionar al menos un producto a producir");
+      return null;
+    }
+    for (const it of selectedItems) {
+      const qty = Number(it.quantity_produced);
+      if (!qty || qty <= 0) {
+        toast.error(`La cantidad producida de "${it.product_name}" debe ser mayor a 0`);
+        return null;
+      }
+      if (qty > it.quantity_pending) {
+        toast.error(
+          `La cantidad producida de "${it.product_name}" no puede superar lo pendiente (${it.quantity_pending})`,
+        );
+        return null;
+      }
+    }
+
+    const batchItems: CreateProductionDocumentBatchItemRequest[] = selectedItems.map((it) => ({
+      production_order_item_id: it.production_order_item_id,
+      quantity_produced: Number(it.quantity_produced),
+      responsible_id: values.responsible_id ? Number(values.responsible_id) : undefined,
+      labor_cost: Number(it.labor_cost) || 0,
+      overhead_cost: Number(it.overhead_cost) || 0,
+      observations: it.observations || undefined,
+    }));
+
+    return {
+      warehouse_origin_id: Number(values.warehouse_origin_id),
+      warehouse_dest_id: Number(values.warehouse_dest_id),
+      production_date: values.production_date,
+      items: batchItems,
+    };
+  };
+
+  const handleFormSubmit = form.handleSubmit(async (values) => {
+    if (!values.production_order_id) {
+      toast.error("Debe seleccionar una orden de producción");
+      return;
+    }
+    const payload = buildPayload(values);
+    if (!payload) return;
+
+    // Verificación de stock: se agregan las cantidades requeridas por
+    // componente entre todos los ítems seleccionados (mismo almacén origen).
+    setCheckingStock(true);
+    try {
+      const neededByComponent = new Map<number, { name: string; quantity: number }>();
+      for (const it of items.filter((i) => i.selected)) {
+        for (const c of it.components) {
+          const prev = neededByComponent.get(c.component_id);
+          neededByComponent.set(c.component_id, {
+            name: c.component.name,
+            quantity: (prev?.quantity ?? 0) + c.quantity_required,
+          });
+        }
+      }
+      const results = await Promise.all(
+        Array.from(neededByComponent.entries()).map(async ([componentId, { name, quantity }]) => {
+          const stockData = await getAllWarehouseProducts({
+            warehouse_id: Number(values.warehouse_origin_id),
+            product_id: componentId,
+          });
+          const available = stockData.find((s) => s.product_id === componentId)?.stock ?? 0;
+          return {
+            component_name: name,
+            component_id: componentId,
+            quantity_needed: quantity,
+            stock_available: available,
+            sufficient: available >= quantity,
+          };
+        }),
+      );
+      setStockResults(results);
+      setPendingPayload(payload);
+      setShowStockDialog(true);
+    } catch {
+      onSubmit(payload);
+    } finally {
+      setCheckingStock(false);
+    }
+  });
+
+  const itemsForOrder = !!order;
+  const noPendingItems = itemsForOrder && items.every((it) => it.quantity_pending <= 0);
+
+  return (
+    <FormWrapper>
+      <div className="mb-6">
+        <div className="flex items-center gap-4 mb-4">
+          <TitleFormComponent title={MODEL.name} mode="create" icon={ICON} backRoute={ROUTE} />
+        </div>
+      </div>
+
+      <Form {...form}>
+        <form onSubmit={handleFormSubmit} className="space-y-6">
+          {fromOrderId ? (
+            <div className="flex items-center gap-2 p-3 bg-blue-50 text-blue-700 rounded-lg border border-blue-200">
+              <ClipboardList className="h-4 w-4 flex-shrink-0" />
+              <span className="text-sm font-medium">
+                Generando documentos desde la Orden de Producción #{fromOrderId}
+              </span>
+            </div>
+          ) : (
+            <FormSelectAsync
+              control={form.control}
+              name="production_order_id"
+              label="Orden de Producción"
+              placeholder="Seleccione una orden aprobada..."
+              useQueryHook={useProductionOrdersSearch}
+              mapOptionFn={(o: ProductionOrderResource) => ({
+                value: o.id.toString(),
+                label: o.order_number,
+                description: `Cant: ${o.total_requested} · ${o.requested_date}`,
+              })}
+              withValue
+            />
+          )}
+
+          {loadingOrder && (
+            <div className="flex items-center gap-2 text-sm text-muted-foreground">
+              <Loader className="h-4 w-4 animate-spin" />
+              Cargando datos de la orden...
+            </div>
+          )}
+
+          {noPendingItems && (
+            <div className="flex items-center gap-2 p-3 bg-amber-50 text-amber-700 rounded-lg border border-amber-200 text-sm">
+              <AlertTriangle className="h-4 w-4 flex-shrink-0" />
+              Esta orden no tiene productos con cantidad pendiente por producir.
+            </div>
+          )}
+
+          {order && (
+            <>
+              {/* Información General */}
+              <GroupFormSection icon={Factory} title="Información General" cols={{ sm: 1, md: 2, lg: 4 }}>
+                <FormSelect
+                  control={form.control}
+                  name="warehouse_origin_id"
+                  label="Almacén Origen"
+                  placeholder="Seleccione almacén de origen"
+                  options={warehouses
+                    .filter((w) => w.id.toString() !== warehouseDestId)
+                    .map((w) => ({ value: w.id.toString(), label: w.name, description: w.address }))}
+                  withValue
+                />
+
+                <FormSelect
+                  control={form.control}
+                  name="warehouse_dest_id"
+                  label="Almacén Destino"
+                  placeholder="Seleccione almacén de destino"
+                  options={warehouses
+                    .filter((w) => w.id.toString() !== warehouseOriginId)
+                    .map((w) => ({ value: w.id.toString(), label: w.name, description: w.address }))}
+                  withValue
+                />
+
+                <FormSelectAsync
+                  control={form.control}
+                  name="responsible_id"
+                  label="Responsable"
+                  placeholder="Seleccione responsable"
+                  useQueryHook={useWorkers}
+                  mapOptionFn={(w: PersonResource) => ({
+                    value: w.id.toString(),
+                    label: w.business_name || `${w.names} ${w.father_surname} ${w.mother_surname}`,
+                    description: w.number_document,
+                  })}
+                  withValue
+                />
+
+                <DatePickerFormField
+                  control={form.control}
+                  name="production_date"
+                  label="Fecha de Producción"
+                  placeholder="Seleccione fecha"
+                  disabledRange={{ after: today }}
+                />
+              </GroupFormSection>
+
+              {/* Productos a producir */}
+              <GroupFormSection icon={Package} title="Productos a Producir" cols={{ sm: 1 }}>
+                <div className="space-y-3 w-full">
+                  {items.map((item, index) => {
+                    const isDone = item.quantity_pending <= 0;
+                    return (
+                      <div
+                        key={item.production_order_item_id}
+                        className={`rounded-xl border bg-card shadow-sm overflow-hidden ${
+                          !item.selected ? "opacity-60" : ""
+                        }`}
+                      >
+                        <div className="flex items-center gap-3 px-3 py-2 bg-muted/40 border-b">
+                          <Checkbox
+                            checked={item.selected}
+                            disabled={isDone}
+                            onCheckedChange={(checked) =>
+                              updateItem(index, { selected: checked === true })
+                            }
+                          />
+                          <span className="text-sm font-semibold flex-1">{item.product_name}</span>
+                          <span className="text-xs text-muted-foreground">
+                            Pendiente: <strong>{item.quantity_pending}</strong>
+                          </span>
+                          {isDone && (
+                            <span className="inline-flex items-center rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-700">
+                              Completado
+                            </span>
+                          )}
+                        </div>
+
+                        {item.selected && !isDone && (
+                          <div className="p-3 space-y-3">
+                            <div className="grid grid-cols-1 md:grid-cols-4 gap-3">
+                              <div>
+                                <label className="text-sm font-medium">Cant. a Producir</label>
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  min="0.01"
+                                  max={item.quantity_pending}
+                                  value={item.quantity_produced}
+                                  onChange={(e) =>
+                                    updateItem(index, { quantity_produced: e.target.value })
+                                  }
+                                />
+                              </div>
+                              <div>
+                                <label className="text-sm font-medium">Costo Laboral (S/)</label>
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  value={item.labor_cost}
+                                  onChange={(e) => updateItem(index, { labor_cost: e.target.value })}
+                                />
+                              </div>
+                              <div>
+                                <label className="text-sm font-medium">Costo Indirecto (S/)</label>
+                                <Input
+                                  type="number"
+                                  step="0.01"
+                                  min="0"
+                                  value={item.overhead_cost}
+                                  onChange={(e) => updateItem(index, { overhead_cost: e.target.value })}
+                                />
+                              </div>
+                              <div>
+                                <label className="text-sm font-medium">Observaciones</label>
+                                <Input
+                                  value={item.observations}
+                                  onChange={(e) => updateItem(index, { observations: e.target.value })}
+                                  placeholder="Opcional"
+                                />
+                              </div>
+                            </div>
+
+                            {item.components.length > 0 && (
+                              <DataTable columns={componentColumns} data={item.components} />
+                            )}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </GroupFormSection>
+            </>
+          )}
+
+          <div className="flex justify-end gap-3">
+            <Button type="button" variant="outline" onClick={() => navigate(ROUTE)}>
+              Cancelar
+            </Button>
+            <Button type="submit" disabled={isSubmitting || checkingStock || !order}>
+              {isSubmitting || checkingStock ? <Loader className="h-4 w-4 animate-spin" /> : "Generar Documentos"}
+            </Button>
+          </div>
+        </form>
+      </Form>
+
+      <AlertDialog open={showStockDialog} onOpenChange={setShowStockDialog}>
+        <AlertDialogContent className="max-w-lg">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              {stockResults.every((r) => r.sufficient) ? (
+                <CheckCircle2 className="h-5 w-5 text-green-600" />
+              ) : (
+                <AlertTriangle className="h-5 w-5 text-amber-500" />
+              )}
+              Verificación de Stock
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {stockResults.every((r) => r.sufficient)
+                ? "Todos los componentes tienen stock suficiente en el almacén origen."
+                : "Algunos componentes no tienen stock suficiente. Puede guardar de todas formas o cancelar para ajustar las cantidades."}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-2 my-1 max-h-64 overflow-y-auto">
+            {stockResults.map((r, i) => (
+              <div
+                key={i}
+                className={`flex items-center justify-between p-2 rounded-md text-sm ${
+                  r.sufficient
+                    ? "bg-green-50 border border-green-200 text-green-800"
+                    : "bg-red-50 border border-red-200 text-red-800"
+                }`}
+              >
+                <div className="flex items-center gap-2 min-w-0">
+                  {r.sufficient ? (
+                    <CheckCircle2 className="h-4 w-4 flex-shrink-0 text-green-600" />
+                  ) : (
+                    <AlertTriangle className="h-4 w-4 flex-shrink-0 text-red-500" />
+                  )}
+                  <span className="font-medium truncate">{r.component_name}</span>
+                </div>
+                <div className="text-right text-xs flex-shrink-0 ml-3 space-y-0.5">
+                  <div>
+                    Necesario: <span className="font-semibold">{r.quantity_needed}</span>
+                  </div>
+                  <div>
+                    Disponible: <span className="font-semibold">{r.stock_available}</span>
+                  </div>
+                  {!r.sufficient && (
+                    <div className="font-bold text-red-700">
+                      Falta: {(r.quantity_needed - r.stock_available).toFixed(2)}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={() => {
+                if (pendingPayload) onSubmit(pendingPayload);
+                setShowStockDialog(false);
+              }}
+            >
+              Confirmar y Guardar
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </FormWrapper>
+  );
+}

--- a/src/pages/production-document/components/ProductionDocumentDetailPage.tsx
+++ b/src/pages/production-document/components/ProductionDocumentDetailPage.tsx
@@ -24,7 +24,7 @@ const statusVariants: Record<
 };
 
 export default function ProductionDocumentDetailPage() {
-  const { ROUTE, ICON } = PRODUCTION_DOCUMENT;
+  const { ROUTE, ROUTE_UPDATE, ICON } = PRODUCTION_DOCUMENT;
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
   const {
@@ -125,23 +125,21 @@ export default function ProductionDocumentDetailPage() {
           />
         </div>
         <div className="flex gap-2">
+          {guide.status === "BORRADOR" && (
+            <Button
+              variant="outline"
+              onClick={() => navigate(ROUTE_UPDATE.replace(":id", id!))}
+            >
+              Actualizar
+            </Button>
+          )}
           {guide.status === "PROCESADO" && (
-            <>
-              <Button
-                variant="outline"
-                onClick={() =>
-                  navigate(`${ROUTE.replace(ROUTE, "")}/actualizar/${id}`)
-                }
-              >
-                Actualizar
-              </Button>
-              <Button
-                variant="destructive"
-                onClick={() => setShowCancelDialog(true)}
-              >
-                Cancelar Documento
-              </Button>
-            </>
+            <Button
+              variant="destructive"
+              onClick={() => setShowCancelDialog(true)}
+            >
+              Cancelar Documento
+            </Button>
           )}
         </div>
       </div>

--- a/src/pages/production-document/components/ProductionDocumentForm.tsx
+++ b/src/pages/production-document/components/ProductionDocumentForm.tsx
@@ -413,21 +413,15 @@ export function ProductionDocumentForm({
                   try {
                     const res = await findProductionOrderById(Number(value));
                     const order = res.data.data;
+                    // ⚠️ La orden ahora agrupa varios productos (items[]),
+                    // cada uno con su propio producto/componentes/costos —
+                    // ya no hay un único producto a nivel de orden para
+                    // autocompletar aquí. Solo se rellenan los datos
+                    // comunes a la orden; el producto y sus componentes se
+                    // completan manualmente más abajo.
                     form.setValue("warehouse_origin_id", order.warehouse_origin_id.toString());
                     form.setValue("warehouse_dest_id", order.warehouse_dest_id.toString());
-                    form.setValue("product_id", order.product_id ? order.product_id.toString() : "");
                     form.setValue("responsible_id", order.responsible_id.toString());
-                    form.setValue("quantity_produced", order.quantity_requested.toString());
-                    form.setValue("labor_cost", order.labor_cost.toString());
-                    const mapped = (order.components ?? []).map((c) => ({
-                      component_id: c.component_id.toString(),
-                      component_name: c.component.name,
-                      quantity_required: c.quantity_required,
-                      quantity_used: c.quantity_required,
-                      unit_cost: c.unit_cost,
-                      notes: c.notes || "",
-                    }));
-                    setComponents(mapped);
                     toast.success("Datos de la orden cargados correctamente");
                   } catch {
                     toast.error("Error al cargar los datos de la orden");

--- a/src/pages/production-document/components/ProductionDocumentForm.tsx
+++ b/src/pages/production-document/components/ProductionDocumentForm.tsx
@@ -406,7 +406,7 @@ export function ProductionDocumentForm({
                 mapOptionFn={(o: ProductionOrderResource) => ({
                   value: o.id.toString(),
                   label: o.order_number,
-                  description: `Cant: ${o.quantity_requested} · ${o.requested_date}`,
+                  description: `Cant: ${o.total_requested} · ${o.requested_date}`,
                 })}
                 onValueChange={async (value) => {
                   if (!value) return;
@@ -415,11 +415,11 @@ export function ProductionDocumentForm({
                     const order = res.data.data;
                     form.setValue("warehouse_origin_id", order.warehouse_origin_id.toString());
                     form.setValue("warehouse_dest_id", order.warehouse_dest_id.toString());
-                    form.setValue("product_id", order.product_id.toString());
+                    form.setValue("product_id", order.product_id ? order.product_id.toString() : "");
                     form.setValue("responsible_id", order.responsible_id.toString());
                     form.setValue("quantity_produced", order.quantity_requested.toString());
                     form.setValue("labor_cost", order.labor_cost.toString());
-                    const mapped = order.components.map((c) => ({
+                    const mapped = (order.components ?? []).map((c) => ({
                       component_id: c.component_id.toString(),
                       component_name: c.component.name,
                       quantity_required: c.quantity_required,

--- a/src/pages/production-document/lib/production-document.actions.ts
+++ b/src/pages/production-document/lib/production-document.actions.ts
@@ -4,11 +4,14 @@ import type {
   ProductionDocumentResourceById,
   ProductionDocumentResponse,
   CreateProductionDocumentRequest,
+  CreateProductionDocumentBatchRequest,
+  ProductionDocumentBatchResponse,
   UpdateProductionDocumentRequest,
   GetProductionDocumentsParams,
 } from "./production-document.interface";
 import {
   PRODUCTION_DOCUMENT_ENDPOINT,
+  PRODUCTION_DOCUMENT_BATCH_ENDPOINT,
 } from "./production-document.interface";
 
 export async function getProductionDocuments(
@@ -39,6 +42,14 @@ export async function findProductionDocumentById(id: number) {
 export async function storeProductionDocument(data: CreateProductionDocumentRequest) {
   const response = await api.post<ProductionDocumentResourceById>(
     PRODUCTION_DOCUMENT_ENDPOINT,
+    data
+  );
+  return response;
+}
+
+export async function storeProductionDocumentBatch(data: CreateProductionDocumentBatchRequest) {
+  const response = await api.post<ProductionDocumentBatchResponse>(
+    PRODUCTION_DOCUMENT_BATCH_ENDPOINT,
     data
   );
   return response;

--- a/src/pages/production-document/lib/production-document.interface.ts
+++ b/src/pages/production-document/lib/production-document.interface.ts
@@ -141,6 +141,37 @@ export interface CreateProductionDocumentRequest {
   components: CreateProductionDocumentComponentRequest[];
 }
 
+// ===== CREATE BATCH (varios documentos desde una orden de producción) =====
+// ✅ Endpoint confirmado por backend: POST /productiondocument/batch. Genera
+// un documento de producción independiente por cada ítem enviado, todos
+// compartiendo almacén origen/destino y fecha de producción. Cada ítem se
+// referencia por "production_order_item_id" (el id del ítem de la orden, NO
+// el product_id), que es lo que permite al backend descontar el pendiente de
+// ese ítem puntual aunque la orden tenga varios productos.
+export interface CreateProductionDocumentBatchItemRequest {
+  production_order_item_id: number;
+  quantity_produced: number;
+  responsible_id?: number | null;
+  labor_cost?: number | null;
+  overhead_cost?: number | null;
+  observations?: string | null;
+  // ⚠️ Opcional: solo se envía si se quiere sobrescribir el BOM del ítem.
+  // Si se omite, el backend usa los componentes ya definidos en la orden.
+  components?: CreateProductionDocumentComponentRequest[] | null;
+}
+
+export interface CreateProductionDocumentBatchRequest {
+  warehouse_origin_id: number;
+  warehouse_dest_id: number;
+  production_date?: string | null;
+  items: CreateProductionDocumentBatchItemRequest[];
+}
+
+export interface ProductionDocumentBatchResponse {
+  message?: string;
+  data: ProductionDocumentResource[];
+}
+
 export interface UpdateProductionDocumentRequest {
   warehouse_origin_id?: number;
   warehouse_dest_id?: number;
@@ -176,6 +207,7 @@ export interface GetProductionDocumentsParams {
 // ===== CONSTANTS =====
 
 export const PRODUCTION_DOCUMENT_ENDPOINT = "/productiondocument";
+export const PRODUCTION_DOCUMENT_BATCH_ENDPOINT = "/productiondocument/batch";
 export const PRODUCTION_DOCUMENT_QUERY_KEY = "production-documents";
 
 // ===== ROUTES =====

--- a/src/pages/production-document/lib/production-document.store.ts
+++ b/src/pages/production-document/lib/production-document.store.ts
@@ -2,6 +2,7 @@ import { create } from "zustand";
 import type {
   ProductionDocumentResource,
   CreateProductionDocumentRequest,
+  CreateProductionDocumentBatchRequest,
   UpdateProductionDocumentRequest,
   GetProductionDocumentsParams,
 } from "./production-document.interface";
@@ -10,6 +11,7 @@ import {
   getAllProductionDocuments,
   findProductionDocumentById,
   storeProductionDocument,
+  storeProductionDocumentBatch,
   updateProductionDocument,
   cancelProductionDocument,
   deleteProductionDocument,
@@ -38,6 +40,9 @@ interface ProductionDocumentStore {
   fetchDocuments: (params?: GetProductionDocumentsParams) => Promise<void>;
   fetchDocument: (id: number) => Promise<void>;
   createDocument: (data: ProductionDocumentSchema) => Promise<void>;
+  createDocumentBatch: (
+    data: CreateProductionDocumentBatchRequest
+  ) => Promise<ProductionDocumentResource[]>;
   updateDocument: (
     id: number,
     data: Partial<ProductionDocumentSchema>
@@ -134,6 +139,20 @@ export const useProductionDocumentStore = create<ProductionDocumentStore>(
 
         await storeProductionDocument(request);
         set({ isSubmitting: false });
+      } catch (error) {
+        set({ error: ERROR_MESSAGE(MODEL, "create"), isSubmitting: false });
+        throw error;
+      }
+    },
+
+    // Crear varios documentos de producción a la vez (uno por ítem de una
+    // orden), en una sola request al endpoint /productiondocument/batch.
+    createDocumentBatch: async (data: CreateProductionDocumentBatchRequest) => {
+      set({ isSubmitting: true, error: null });
+      try {
+        const response = await storeProductionDocumentBatch(data);
+        set({ isSubmitting: false });
+        return response.data.data;
       } catch (error) {
         set({ error: ERROR_MESSAGE(MODEL, "create"), isSubmitting: false });
         throw error;

--- a/src/pages/production-order/components/ProductionOrderAddPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderAddPage.tsx
@@ -1,26 +1,21 @@
 import { useNavigate } from "react-router-dom";
-import { useProductionOrderStore } from "../lib/production-order.store";
-import { ERROR_MESSAGE, SUCCESS_MESSAGE, errorToast, successToast } from "@/lib/core.function";
+import { useCreateProductionOrder } from "../lib/production-order.hook";
 import { PRODUCTION_ORDER } from "../lib/production-order.interface";
 import { ProductionOrderForm, type ProductionOrderFormValues } from "./ProductionOrderForm";
 import { useAllWarehouses } from "@/pages/warehouse/lib/warehouse.hook";
 import PageSkeleton from "@/components/PageSkeleton";
 
 export default function ProductionOrderAddPage() {
-  const { ROUTE, MODEL } = PRODUCTION_ORDER;
+  const { ROUTE } = PRODUCTION_ORDER;
   const navigate = useNavigate();
-  const { createOrder, isSubmitting } = useProductionOrderStore();
+  const createOrder = useCreateProductionOrder();
 
   const { data: warehouses = [], isLoading: loadingWarehouses } = useAllWarehouses();
 
-  const onSubmit = async (values: ProductionOrderFormValues) => {
-    try {
-      await createOrder(values as any);
-      successToast(SUCCESS_MESSAGE(MODEL, "create"));
-      navigate(ROUTE);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || ERROR_MESSAGE(MODEL, "create"));
-    }
+  const onSubmit = (values: ProductionOrderFormValues) => {
+    createOrder.mutate(values as any, {
+      onSuccess: () => navigate(ROUTE),
+    });
   };
 
   if (loadingWarehouses) {
@@ -31,7 +26,7 @@ export default function ProductionOrderAddPage() {
     <ProductionOrderForm
       mode="create"
       onSubmit={onSubmit}
-      isSubmitting={isSubmitting}
+      isSubmitting={createOrder.isPending}
       warehouses={warehouses || []}
     />
   );

--- a/src/pages/production-order/components/ProductionOrderColumns.tsx
+++ b/src/pages/production-order/components/ProductionOrderColumns.tsx
@@ -88,11 +88,18 @@ export const createProductionOrderColumns = (
     ),
   },
   {
-    accessorKey: "quantity_requested",
+    id: "items_count",
+    header: "Ítems",
+    cell: ({ row }) => (
+      <span className="text-sm">{row.original.items?.length ?? 0}</span>
+    ),
+  },
+  {
+    accessorKey: "total_requested",
     header: "Cant. Solicitada",
     cell: ({ row }) => (
       <div>
-        <div className="font-medium">{row.original.quantity_requested}</div>
+        <div className="font-medium">{row.original.total_requested}</div>
         <div className="text-sm text-muted-foreground">
           {row.original.currency}
         </div>
@@ -100,30 +107,29 @@ export const createProductionOrderColumns = (
     ),
   },
   {
-    accessorKey: "estimated_component_cost",
-    header: "Costo Componentes",
+    accessorKey: "total_produced",
+    header: "Cant. Producida",
+    cell: ({ row }) => <span>{row.original.total_produced}</span>,
+  },
+  {
+    accessorKey: "total_pending",
+    header: "Cant. Pendiente",
     cell: ({ row }) => (
-      <span>S/ {row.original.estimated_component_cost.toFixed(2)}</span>
-    ),
-  },
-  {
-    accessorKey: "labor_cost",
-    header: "C. Laboral",
-    cell: ({ row }) => <span>S/ {row.original.labor_cost.toFixed(2)}</span>,
-  },
-  {
-    accessorKey: "overhead_cost",
-    header: "C. Indirecto",
-    cell: ({ row }) => <span>S/ {(row.original.overhead_cost ?? 0).toFixed(2)}</span>,
-  },
-  {
-    accessorKey: "estimated_total_cost",
-    header: "Costo Total",
-    cell: ({ row }) => (
-      <span className="font-semibold">
-        S/ {row.original.estimated_total_cost.toFixed(2)}
+      <span className="font-semibold text-amber-600">
+        {row.original.total_pending}
       </span>
     ),
+  },
+  {
+    id: "estimated_total_cost",
+    header: "Costo Total",
+    cell: ({ row }) => {
+      const total = (row.original.items ?? []).reduce(
+        (sum, item) => sum + (item.estimated_total_cost ?? 0),
+        0,
+      );
+      return <span className="font-semibold">S/ {total.toFixed(2)}</span>;
+    },
   },
   {
     accessorKey: "status",
@@ -145,7 +151,7 @@ export const createProductionOrderColumns = (
     id: "actions",
     header: "Acciones",
     cell: ({ row }) => {
-      const { id, status, production_document_id } = row.original;
+      const { id, status, total_pending } = row.original;
       const canEdit = status === "BORRADOR" || status === "RECHAZADO";
       const canSubmit = status === "BORRADOR" || status === "RECHAZADO";
       const canApprove =
@@ -154,6 +160,11 @@ export const createProductionOrderColumns = (
         status === "PENDIENTE" && callbacks.canReject !== false;
       const canCancel = status !== "PROCESADO" && status !== "ANULADO";
       const canDelete = status === "BORRADOR" || status === "RECHAZADO";
+      // ⚠️ El listado ya no trae "production_document_id" a nivel de orden
+      // (ese campo era del modelo viejo de 1 solo ítem). Con items[], la
+      // señal de "todavía se puede generar documento" es que quede cantidad
+      // pendiente de producir en la orden aprobada.
+      const canGenerateDocument = status === "APROBADO" && total_pending > 0;
 
       return (
         <ColumnActions>
@@ -211,16 +222,14 @@ export const createProductionOrderColumns = (
             onClick={() => callbacks.onRejectClick!(id)}
           />
 
-          {callbacks.onGenerateDocument &&
-            status === "APROBADO" &&
-            production_document_id === null && (
-              <ButtonAction
-                icon={FilePlus}
-                color="indigo"
-                tooltip="Generar Documento de Producción"
-                onClick={() => callbacks.onGenerateDocument!(id)}
-              />
-            )}
+          {callbacks.onGenerateDocument && canGenerateDocument && (
+            <ButtonAction
+              icon={FilePlus}
+              color="indigo"
+              tooltip="Generar Documento de Producción"
+              onClick={() => callbacks.onGenerateDocument!(id)}
+            />
+          )}
 
           {canCancel && callbacks.onCancel && (
             <ConfirmationDialog

--- a/src/pages/production-order/components/ProductionOrderDetailPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderDetailPage.tsx
@@ -29,7 +29,6 @@ import {
   Package,
   ClipboardList,
   AlertCircle,
-  DollarSign,
   Users,
   Pencil,
   Send,
@@ -42,6 +41,7 @@ import {
 import { PRODUCTION_ORDER } from "../lib/production-order.interface";
 import type {
   ProductionOrderComponentResource,
+  ProductionOrderDetailItem,
   ProductionOrderStatus,
 } from "../lib/production-order.interface";
 import TitleFormComponent from "@/components/TitleFormComponent";
@@ -58,6 +58,71 @@ const statusConfig: Record<
   PROCESADO: { label: "Procesado", dot: "bg-blue-500",   text: "text-blue-700",   bg: "bg-blue-100"   },
   ANULADO:   { label: "Anulado",   dot: "bg-zinc-400",   text: "text-zinc-600",   bg: "bg-zinc-100"   },
 };
+
+const itemStatusColor: Record<string, string> = {
+  PENDIENTE: "bg-amber-100 text-amber-700",
+  EN_PROCESO: "bg-blue-100 text-blue-700",
+  PROCESADO: "bg-green-100 text-green-700",
+};
+
+const itemColumns: ColumnDef<ProductionOrderDetailItem>[] = [
+  {
+    accessorKey: "product",
+    header: "Producto",
+    cell: ({ row }) => (
+      <div>
+        <div className="font-medium">{row.original.product.name}</div>
+        <div className="text-sm text-muted-foreground">
+          {row.original.product.category_name} · {row.original.product.unit_name}
+        </div>
+      </div>
+    ),
+  },
+  {
+    accessorKey: "quantity_requested",
+    header: "Solicitada",
+    cell: ({ row }) => <span>{row.original.quantity_requested}</span>,
+  },
+  {
+    accessorKey: "quantity_produced",
+    header: "Producida",
+    cell: ({ row }) => <span>{row.original.quantity_produced}</span>,
+  },
+  {
+    accessorKey: "quantity_pending",
+    header: "Pendiente",
+    cell: ({ row }) => (
+      <span className="font-semibold">{row.original.quantity_pending}</span>
+    ),
+  },
+  {
+    accessorKey: "progress_percentage",
+    header: "Avance",
+    cell: ({ row }) => <span>{row.original.progress_percentage}%</span>,
+  },
+  {
+    accessorKey: "estimated_total_cost",
+    header: "Costo Estimado",
+    cell: ({ row }) => (
+      <span className="font-semibold">
+        S/ {row.original.estimated_total_cost.toFixed(2)}
+      </span>
+    ),
+  },
+  {
+    accessorKey: "status",
+    header: "Estado",
+    cell: ({ row }) => (
+      <span
+        className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${
+          itemStatusColor[row.original.status] ?? "bg-slate-100 text-slate-700"
+        }`}
+      >
+        {row.original.status}
+      </span>
+    ),
+  },
+];
 
 const componentColumns: ColumnDef<ProductionOrderComponentResource>[] = [
   {
@@ -280,30 +345,19 @@ export default function ProductionOrderDetailPage() {
             <p className="font-mono font-bold text-lg">{order.order_number}</p>
           </div>
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Cantidad Solicitada</p>
-            <p className="text-lg font-bold">{order.quantity_requested}</p>
+            <p className="text-xs text-muted-foreground">Cant. Solicitada / Producida</p>
+            <p className="text-lg font-bold">
+              {order.total_requested} / {order.total_produced}
+            </p>
           </div>
           <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Costo Total Estimado</p>
-            <p className="text-lg font-bold">S/ {order.estimated_total_cost.toFixed(2)}</p>
+            <p className="text-xs text-muted-foreground">Cantidad Pendiente</p>
+            <p className="text-lg font-bold">{order.total_pending}</p>
           </div>
         </GroupFormSection>
 
-        {/* Producto y Fechas */}
-        <GroupFormSection title="Producto y Fechas" icon={Package} cols={{ sm: 1, md: 2, lg: 3 }}>
-          <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Producto</p>
-            {order.product ? (
-              <>
-                <p className="font-semibold">{order.product.name}</p>
-                <p className="text-sm text-muted-foreground">
-                  {order.product.category_name} · {order.product.unit_name}
-                </p>
-              </>
-            ) : (
-              <p className="text-sm text-muted-foreground">Sin producto asociado</p>
-            )}
-          </div>
+        {/* Fechas y Moneda */}
+        <GroupFormSection title="Fechas y Moneda" icon={Package} cols={{ sm: 1, md: 2, lg: 3 }}>
           <div className="space-y-1">
             <p className="text-xs text-muted-foreground">Fecha Solicitada</p>
             <p className="font-medium">{order.requested_date}</p>
@@ -355,12 +409,12 @@ export default function ProductionOrderDetailPage() {
           </div>
           <div className="space-y-1">
             <p className="text-xs text-muted-foreground">Responsable</p>
-            <p className="font-semibold">{order.responsible.name || "-"}</p>
-            {order.responsible.person && (
-              <p className="text-sm text-muted-foreground">
-                {order.responsible.person.full_name}
-              </p>
-            )}
+            <p className="font-semibold">
+              {[order.responsible.names, order.responsible.father_surname, order.responsible.mother_surname]
+                .filter(Boolean)
+                .join(" ") || "-"}
+            </p>
+            <p className="text-sm text-muted-foreground">{order.responsible.number_document}</p>
           </div>
           {order.approved_by && (
             <div className="space-y-1">
@@ -373,28 +427,6 @@ export default function ProductionOrderDetailPage() {
               )}
             </div>
           )}
-        </GroupFormSection>
-
-        {/* Costos */}
-        <GroupFormSection title="Detalles de Costos" icon={DollarSign} cols={{ sm: 2, md: 4 }}>
-          <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Costo de Componentes</p>
-            <p className="text-lg font-bold">S/ {order.estimated_component_cost.toFixed(2)}</p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Costo Laboral</p>
-            <p className="text-lg font-bold">S/ {order.labor_cost.toFixed(2)}</p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Costo Indirecto</p>
-            <p className="text-lg font-bold">S/ {(order.overhead_cost ?? 0).toFixed(2)}</p>
-          </div>
-          <div className="space-y-1">
-            <p className="text-xs text-muted-foreground">Costo Total Estimado</p>
-            <p className="text-lg font-bold text-primary">
-              S/ {order.estimated_total_cost.toFixed(2)}
-            </p>
-          </div>
         </GroupFormSection>
 
         {/* Razón de rechazo */}
@@ -411,9 +443,30 @@ export default function ProductionOrderDetailPage() {
           </GroupFormSection>
         )}
 
-        {/* Componentes */}
-        <GroupFormSection title="Componentes" icon={Package} cols={{ sm: 1 }}>
-          <DataTable columns={componentColumns} data={order.components || []} />
+        {/* Productos a producir (ítems) */}
+        <GroupFormSection title="Productos a Producir" icon={Package} cols={{ sm: 1 }}>
+          <DataTable columns={itemColumns} data={order.items} />
+        </GroupFormSection>
+
+        {/* Componentes por producto */}
+        <GroupFormSection title="Componentes por Producto" icon={Package} cols={{ sm: 1 }}>
+          <div className="space-y-4">
+            {order.items.map((item) => (
+              <div key={item.id} className="rounded-xl border bg-card shadow-sm overflow-hidden">
+                <div className="flex items-center justify-between px-3 py-2 bg-muted/40 border-b">
+                  <span className="text-sm font-semibold">{item.product.name}</span>
+                  <span className="text-xs text-muted-foreground">
+                    Costo componentes: S/ {item.estimated_component_cost.toFixed(2)} · Laboral: S/{" "}
+                    {item.labor_cost.toFixed(2)} · Indirecto: S/ {item.overhead_cost.toFixed(2)} · Total: S/{" "}
+                    {item.estimated_total_cost.toFixed(2)}
+                  </span>
+                </div>
+                <div className="p-3">
+                  <DataTable columns={componentColumns} data={item.components || []} />
+                </div>
+              </div>
+            ))}
+          </div>
         </GroupFormSection>
       </div>
 

--- a/src/pages/production-order/components/ProductionOrderDetailPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderDetailPage.tsx
@@ -37,6 +37,7 @@ import {
   Ban,
   Trash2,
   Loader,
+  History,
 } from "lucide-react";
 import { PRODUCTION_ORDER } from "../lib/production-order.interface";
 import type {
@@ -46,6 +47,7 @@ import type {
 } from "../lib/production-order.interface";
 import TitleFormComponent from "@/components/TitleFormComponent";
 import { useAuthStore } from "@/pages/auth/lib/auth.store";
+import { ProductionOrderItemHistoryDialog } from "./ProductionOrderItemHistoryDialog";
 
 const statusConfig: Record<
   ProductionOrderStatus,
@@ -203,6 +205,16 @@ export default function ProductionOrderDetailPage() {
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
   const [rejectionReason, setRejectionReason] = useState("");
   const [rejectionReasonError, setRejectionReasonError] = useState("");
+
+  const [historyDialogOpen, setHistoryDialogOpen] = useState(false);
+  const [historyItemId, setHistoryItemId] = useState<number | null>(null);
+  const [historyProductName, setHistoryProductName] = useState<string>("");
+
+  const handleViewHistory = (item: ProductionOrderDetailItem) => {
+    setHistoryItemId(item.id);
+    setHistoryProductName(item.product.name);
+    setHistoryDialogOpen(true);
+  };
 
   const handleSubmit = () => submitOrder.mutate(numId);
 
@@ -455,11 +467,22 @@ export default function ProductionOrderDetailPage() {
               <div key={item.id} className="rounded-xl border bg-card shadow-sm overflow-hidden">
                 <div className="flex items-center justify-between px-3 py-2 bg-muted/40 border-b">
                   <span className="text-sm font-semibold">{item.product.name}</span>
-                  <span className="text-xs text-muted-foreground">
-                    Costo componentes: S/ {item.estimated_component_cost.toFixed(2)} · Laboral: S/{" "}
-                    {item.labor_cost.toFixed(2)} · Indirecto: S/ {item.overhead_cost.toFixed(2)} · Total: S/{" "}
-                    {item.estimated_total_cost.toFixed(2)}
-                  </span>
+                  <div className="flex items-center gap-3">
+                    <span className="text-xs text-muted-foreground">
+                      Costo componentes: S/ {item.estimated_component_cost.toFixed(2)} · Laboral: S/{" "}
+                      {item.labor_cost.toFixed(2)} · Indirecto: S/ {item.overhead_cost.toFixed(2)} · Total: S/{" "}
+                      {item.estimated_total_cost.toFixed(2)}
+                    </span>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-7"
+                      onClick={() => handleViewHistory(item)}
+                    >
+                      <History className="h-3.5 w-3.5 mr-1.5" />
+                      Historial
+                    </Button>
+                  </div>
                 </div>
                 <div className="p-3">
                   <DataTable columns={componentColumns} data={item.components || []} />
@@ -532,6 +555,14 @@ export default function ProductionOrderDetailPage() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
+
+      {/* Dialog de Historial de Producción del Ítem */}
+      <ProductionOrderItemHistoryDialog
+        open={historyDialogOpen}
+        onOpenChange={setHistoryDialogOpen}
+        itemId={historyItemId}
+        productName={historyProductName}
+      />
     </FormWrapper>
   );
 }

--- a/src/pages/production-order/components/ProductionOrderDetailPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderDetailPage.tsx
@@ -1,6 +1,13 @@
 import { useNavigate, useParams } from "react-router-dom";
-import { useEffect, useState } from "react";
-import { useProductionOrderStore } from "../lib/production-order.store";
+import { useState } from "react";
+import {
+  useProductionOrderById,
+  useDeleteProductionOrder,
+  useSubmitProductionOrder,
+  useApproveProductionOrder,
+  useRejectProductionOrder,
+  useCancelProductionOrder,
+} from "../lib/production-order.hook";
 import FormWrapper from "@/components/FormWrapper";
 import FormSkeleton from "@/components/FormSkeleton";
 import { Button } from "@/components/ui/button";
@@ -32,7 +39,6 @@ import {
   Trash2,
   Loader,
 } from "lucide-react";
-import { successToast, errorToast } from "@/lib/core.function";
 import { PRODUCTION_ORDER } from "../lib/production-order.interface";
 import type {
   ProductionOrderComponentResource,
@@ -105,16 +111,13 @@ export default function ProductionOrderDetailPage() {
   const { ROUTE, ROUTE_UPDATE, ICON } = PRODUCTION_ORDER;
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const {
-    order,
-    fetchOrder,
-    removeOrder,
-    submitOrder,
-    approveOrder,
-    rejectOrder,
-    cancelOrder,
-    isFinding,
-  } = useProductionOrderStore();
+  const numId = Number(id);
+  const { data: order, isLoading: isFinding } = useProductionOrderById(numId);
+  const removeOrder = useDeleteProductionOrder();
+  const submitOrder = useSubmitProductionOrder();
+  const approveOrder = useApproveProductionOrder();
+  const rejectOrder = useRejectProductionOrder();
+  const cancelOrder = useCancelProductionOrder();
   const { access, user } = useAuthStore();
 
   const canApprovePermission =
@@ -135,72 +138,30 @@ export default function ProductionOrderDetailPage() {
   const [rejectDialogOpen, setRejectDialogOpen] = useState(false);
   const [rejectionReason, setRejectionReason] = useState("");
   const [rejectionReasonError, setRejectionReasonError] = useState("");
-  const [isActionLoading, setIsActionLoading] = useState(false);
 
-  useEffect(() => {
-    if (id) fetchOrder(parseInt(id));
-  }, [id, fetchOrder]);
+  const handleSubmit = () => submitOrder.mutate(numId);
 
-  const numId = () => parseInt(id!);
+  const handleApprove = () => approveOrder.mutate(numId);
 
-  const handleSubmit = async () => {
-    try {
-      await submitOrder(numId());
-      successToast("Orden enviada a revisión correctamente");
-      fetchOrder(numId());
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al enviar la orden");
-    }
-  };
+  const handleCancel = () => cancelOrder.mutate(numId);
 
-  const handleApprove = async () => {
-    try {
-      await approveOrder(numId());
-      successToast("Orden aprobada correctamente");
-      fetchOrder(numId());
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al aprobar la orden");
-    }
-  };
+  const handleDelete = () => removeOrder.mutate(numId, { onSuccess: () => navigate(ROUTE) });
 
-  const handleCancel = async () => {
-    try {
-      await cancelOrder(numId());
-      successToast("Orden anulada correctamente");
-      fetchOrder(numId());
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al anular la orden");
-    }
-  };
-
-  const handleDelete = async () => {
-    try {
-      await removeOrder(numId());
-      successToast("Orden eliminada correctamente");
-      navigate(ROUTE);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al eliminar la orden");
-    }
-  };
-
-  const handleReject = async () => {
+  const handleReject = () => {
     if (rejectionReason.trim().length < 4) {
       setRejectionReasonError("El motivo debe tener al menos 4 caracteres");
       return;
     }
-    setIsActionLoading(true);
-    try {
-      await rejectOrder(numId(), rejectionReason.trim());
-      successToast("Orden rechazada correctamente");
-      setRejectDialogOpen(false);
-      setRejectionReason("");
-      setRejectionReasonError("");
-      fetchOrder(numId());
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al rechazar la orden");
-    } finally {
-      setIsActionLoading(false);
-    }
+    rejectOrder.mutate(
+      { id: numId, rejection_reason: rejectionReason.trim() },
+      {
+        onSuccess: () => {
+          setRejectDialogOpen(false);
+          setRejectionReason("");
+          setRejectionReasonError("");
+        },
+      },
+    );
   };
 
   if (isFinding || !order) {
@@ -332,10 +293,16 @@ export default function ProductionOrderDetailPage() {
         <GroupFormSection title="Producto y Fechas" icon={Package} cols={{ sm: 1, md: 2, lg: 3 }}>
           <div className="space-y-1">
             <p className="text-xs text-muted-foreground">Producto</p>
-            <p className="font-semibold">{order.product.name}</p>
-            <p className="text-sm text-muted-foreground">
-              {order.product.category_name} · {order.product.unit_name}
-            </p>
+            {order.product ? (
+              <>
+                <p className="font-semibold">{order.product.name}</p>
+                <p className="text-sm text-muted-foreground">
+                  {order.product.category_name} · {order.product.unit_name}
+                </p>
+              </>
+            ) : (
+              <p className="text-sm text-muted-foreground">Sin producto asociado</p>
+            )}
           </div>
           <div className="space-y-1">
             <p className="text-xs text-muted-foreground">Fecha Solicitada</p>
@@ -493,16 +460,16 @@ export default function ProductionOrderDetailPage() {
             <Button
               variant="outline"
               onClick={() => setRejectDialogOpen(false)}
-              disabled={isActionLoading}
+              disabled={rejectOrder.isPending}
             >
               Cancelar
             </Button>
             <Button
               variant="destructive"
               onClick={handleReject}
-              disabled={isActionLoading}
+              disabled={rejectOrder.isPending}
             >
-              {isActionLoading ? (
+              {rejectOrder.isPending ? (
                 <Loader className="h-4 w-4 animate-spin mr-2" />
               ) : (
                 <XCircle className="h-4 w-4 mr-2" />

--- a/src/pages/production-order/components/ProductionOrderEditPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderEditPage.tsx
@@ -30,11 +30,8 @@ export default function ProductionOrderEditPage() {
     return <PageSkeleton />;
   }
 
-  // ⚠️ El GET /production-orders/{id} todavía no expone "items[]" por
-  // separado: sigue devolviendo un único "product" y un arreglo plano
-  // "components" a nivel de orden. Se reconstruye como un solo ítem —
-  // si la orden real tiene varios productos, esta edición solo mostrará
-  // el primero hasta que el backend exponga el detalle por ítems.
+  // ✅ El GET /production-orders/{id} ya expone "items[]": se reconstruyen
+  // todos los productos de la orden (antes solo se podía editar el primero).
   const initialValues: ProductionOrderFormValues = {
     warehouse_origin_id: order.warehouse_origin_id.toString(),
     warehouse_dest_id: order.warehouse_dest_id.toString(),
@@ -42,26 +39,24 @@ export default function ProductionOrderEditPage() {
     requested_date: order.requested_date,
     currency: order.currency || "PEN",
     observations: order.observations || "",
-    items: [
-      {
-        product_id: order.product_id ? order.product_id.toString() : "",
-        product_name: order.product?.name ?? "",
-        quantity_requested: order.quantity_requested.toString(),
-        labor_cost: order.labor_cost.toString(),
-        // overhead_cost no se edita: lo calcula el backend automáticamente.
-        notes: "",
-        use_combo: (order.components?.length ?? 0) === 0,
-        components: (order.components ?? []).map((c) => ({
-          component_id: c.component_id.toString(),
-          component_name: c.component.name,
-          quantity_required: c.quantity_required.toString(),
-          unit_cost: c.unit_cost.toString(),
-          // waste_quantity/waste_percentage no se editan: los calcula el
-          // backend automáticamente, solo se muestran en el detalle.
-          notes: c.notes || "",
-        })),
-      },
-    ],
+    items: order.items.map((item) => ({
+      product_id: item.product_id.toString(),
+      product_name: item.product?.name ?? "",
+      quantity_requested: item.quantity_requested.toString(),
+      labor_cost: item.labor_cost.toString(),
+      // overhead_cost no se edita: lo calcula el backend automáticamente.
+      notes: item.notes || "",
+      use_combo: (item.components?.length ?? 0) === 0,
+      components: (item.components ?? []).map((c) => ({
+        component_id: c.component_id.toString(),
+        component_name: c.component.name,
+        quantity_required: c.quantity_required.toString(),
+        unit_cost: c.unit_cost.toString(),
+        // waste_quantity/waste_percentage no se editan: los calcula el
+        // backend automáticamente, solo se muestran en el detalle.
+        notes: c.notes || "",
+      })),
+    })),
   };
 
   return (
@@ -71,7 +66,6 @@ export default function ProductionOrderEditPage() {
       isSubmitting={updateOrder.isPending}
       initialValues={initialValues}
       warehouses={warehouses || []}
-      editSingleItemWarning
     />
   );
 }

--- a/src/pages/production-order/components/ProductionOrderEditPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderEditPage.tsx
@@ -1,37 +1,29 @@
 import { useNavigate, useParams } from "react-router-dom";
-import { useEffect } from "react";
-import { useProductionOrderStore } from "../lib/production-order.store";
-import { ERROR_MESSAGE, SUCCESS_MESSAGE, errorToast, successToast } from "@/lib/core.function";
+import { useProductionOrderById, useUpdateProductionOrder } from "../lib/production-order.hook";
 import { PRODUCTION_ORDER } from "../lib/production-order.interface";
 import { ProductionOrderForm, type ProductionOrderFormValues } from "./ProductionOrderForm";
 import { useAllWarehouses } from "@/pages/warehouse/lib/warehouse.hook";
 import PageSkeleton from "@/components/PageSkeleton";
 
 export default function ProductionOrderEditPage() {
-  const { ROUTE, MODEL } = PRODUCTION_ORDER;
+  const { ROUTE } = PRODUCTION_ORDER;
   const { id } = useParams<{ id: string }>();
   const navigate = useNavigate();
-  const { order, fetchOrder, updateOrder, isSubmitting, isFinding } = useProductionOrderStore();
+  const numId = Number(id);
+
+  const { data: order, isLoading: isFinding } = useProductionOrderById(numId);
+  const updateOrder = useUpdateProductionOrder();
 
   const { data: warehouses = [], isLoading: loadingWarehouses } = useAllWarehouses();
 
-  useEffect(() => {
-    if (id) {
-      fetchOrder(parseInt(id));
-    }
-  }, [id, fetchOrder]);
-
   const isLoading = loadingWarehouses || isFinding;
 
-  const onSubmit = async (values: ProductionOrderFormValues) => {
+  const onSubmit = (values: ProductionOrderFormValues) => {
     if (!id) return;
-    try {
-      await updateOrder(parseInt(id), values as any);
-      successToast(SUCCESS_MESSAGE(MODEL, "edit"));
-      navigate(ROUTE);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || ERROR_MESSAGE(MODEL, "edit"));
-    }
+    updateOrder.mutate(
+      { id: numId, data: values as any },
+      { onSuccess: () => navigate(ROUTE) },
+    );
   };
 
   if (isLoading || !order) {
@@ -52,14 +44,14 @@ export default function ProductionOrderEditPage() {
     observations: order.observations || "",
     items: [
       {
-        product_id: order.product_id.toString(),
-        product_name: order.product.name,
+        product_id: order.product_id ? order.product_id.toString() : "",
+        product_name: order.product?.name ?? "",
         quantity_requested: order.quantity_requested.toString(),
         labor_cost: order.labor_cost.toString(),
         // overhead_cost no se edita: lo calcula el backend automáticamente.
         notes: "",
-        use_combo: order.components.length === 0,
-        components: order.components.map((c) => ({
+        use_combo: (order.components?.length ?? 0) === 0,
+        components: (order.components ?? []).map((c) => ({
           component_id: c.component_id.toString(),
           component_name: c.component.name,
           quantity_required: c.quantity_required.toString(),
@@ -76,7 +68,7 @@ export default function ProductionOrderEditPage() {
     <ProductionOrderForm
       mode="edit"
       onSubmit={onSubmit}
-      isSubmitting={isSubmitting}
+      isSubmitting={updateOrder.isPending}
       initialValues={initialValues}
       warehouses={warehouses || []}
       editSingleItemWarning

--- a/src/pages/production-order/components/ProductionOrderForm.tsx
+++ b/src/pages/production-order/components/ProductionOrderForm.tsx
@@ -523,13 +523,13 @@ export function ProductionOrderForm({
 
       <Form {...form}>
         <form onSubmit={handleFormSubmit} className="space-y-6">
-          <div className="grid grid-cols-1 lg:grid-cols-4 gap-6 items-start">
+          <div className="grid grid-cols-1 xl:grid-cols-4 gap-6 items-start">
             {/* Información General */}
-            <div className="lg:col-span-1 lg:sticky lg:top-4">
+            <div className="lg:col-span-1 lg:sticky lg:top-4 gap-6">
               <GroupFormSection
                 icon={ClipboardList}
                 title="Información General"
-                cols={{ sm: 1 }}
+                cols={{ sm: 1, md: 2, xl: 1 }}
               >
                 <FormSelect
                   control={form.control}
@@ -794,7 +794,9 @@ export function ProductionOrderForm({
                                   <TableHead className="w-28 border-r">
                                     Costo Unit.
                                   </TableHead>
-                                  <TableHead className="border-r">Notas</TableHead>
+                                  <TableHead className="border-r">
+                                    Notas
+                                  </TableHead>
                                   <TableHead className="w-10" />
                                 </TableRow>
                               </TableHeader>
@@ -808,7 +810,9 @@ export function ProductionOrderForm({
                                         componentIndex={componentIndex}
                                         component={component}
                                         otherComponentIds={item.components
-                                          .filter((_, ci) => ci !== componentIndex)
+                                          .filter(
+                                            (_, ci) => ci !== componentIndex,
+                                          )
                                           .map((c) => c.component_id)
                                           .filter(Boolean)}
                                         onChange={updateComponentRow}

--- a/src/pages/production-order/components/ProductionOrderForm.tsx
+++ b/src/pages/production-order/components/ProductionOrderForm.tsx
@@ -86,8 +86,6 @@ interface ProductionOrderFormProps {
   isSubmitting?: boolean;
   initialValues?: ProductionOrderFormValues;
   warehouses: WarehouseResource[];
-  /** El GET por id todavía no expone items[] por separado: en edición solo se puede reconstruir 1 ítem */
-  editSingleItemWarning?: boolean;
 }
 
 const CURRENCY_OPTIONS = [
@@ -318,7 +316,6 @@ export function ProductionOrderForm({
   isSubmitting = false,
   initialValues,
   warehouses,
-  editSingleItemWarning = false,
 }: ProductionOrderFormProps) {
   const { ROUTE, MODEL, ICON } = PRODUCTION_ORDER;
   const navigate = useNavigate();
@@ -512,14 +509,6 @@ export function ProductionOrderForm({
           backRoute={ROUTE}
         />
       </div>
-
-      {editSingleItemWarning && (
-        <div className="mb-4 rounded-lg border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">
-          Esta orden fue creada con un solo producto o el backend aún no expone
-          el detalle por múltiples ítems al editar. Si la orden tiene más de un
-          producto, edítala con cuidado: solo se muestra el primero.
-        </div>
-      )}
 
       <Form {...form}>
         <form onSubmit={handleFormSubmit} className="space-y-6">

--- a/src/pages/production-order/components/ProductionOrderIndexPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderIndexPage.tsx
@@ -1,7 +1,14 @@
 import { useNavigate } from "react-router-dom";
 import { useMemo, useState } from "react";
-import { useProductionOrders, useProductionOrdersSummary } from "../lib/production-order.hook";
-import { useProductionOrderStore } from "../lib/production-order.store";
+import {
+  useProductionOrders,
+  useProductionOrdersSummary,
+  useSubmitProductionOrder,
+  useApproveProductionOrder,
+  useRejectProductionOrder,
+  useCancelProductionOrder,
+  useDeleteProductionOrder,
+} from "../lib/production-order.hook";
 import { PRODUCTION_ORDER, ProductionOrderPendingRoute } from "../lib/production-order.interface";
 import type { GetProductionOrdersParams } from "../lib/production-order.interface";
 import { createProductionOrderColumns } from "./ProductionOrderColumns";
@@ -24,7 +31,6 @@ import {
 } from "lucide-react";
 import TitleComponent from "@/components/TitleComponent";
 import DataTablePagination from "@/components/DataTablePagination";
-import { successToast, errorToast } from "@/lib/core.function";
 import {
   Dialog,
   DialogContent,
@@ -65,82 +71,45 @@ export default function ProductionOrderIndexPage() {
     [page, perPage],
   );
 
-  const {
-    data: orders,
-    meta,
-    isLoading,
-    refetch,
-  } = useProductionOrders(params);
-  const { submitOrder, approveOrder, rejectOrder, cancelOrder, removeOrder } =
-    useProductionOrderStore();
+  const { data: orders, meta, isLoading } = useProductionOrders(params);
   const { data: summary, isLoading: isLoadingSummary } = useProductionOrdersSummary();
+
+  const submitOrder = useSubmitProductionOrder();
+  const approveOrder = useApproveProductionOrder();
+  const rejectOrder = useRejectProductionOrder();
+  const cancelOrder = useCancelProductionOrder();
+  const removeOrder = useDeleteProductionOrder();
 
   // Reject dialog state
   const [rejectingId, setRejectingId] = useState<number | null>(null);
   const [rejectionReason, setRejectionReason] = useState("");
   const [rejectionReasonError, setRejectionReasonError] = useState("");
-  const [isRejectLoading, setIsRejectLoading] = useState(false);
 
-  const handleSubmit = async (id: number) => {
-    try {
-      await submitOrder(id);
-      successToast("Orden enviada a revisión correctamente");
-      refetch(params);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al enviar la orden");
-    }
-  };
+  const handleSubmit = (id: number) => submitOrder.mutate(id);
 
-  const handleApprove = async (id: number) => {
-    try {
-      await approveOrder(id);
-      successToast("Orden aprobada correctamente");
-      refetch(params);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al aprobar la orden");
-    }
-  };
+  const handleApprove = (id: number) => approveOrder.mutate(id);
 
-  const handleReject = async () => {
+  const handleReject = () => {
     if (rejectionReason.trim().length < 4) {
       setRejectionReasonError("El motivo debe tener al menos 4 caracteres");
       return;
     }
     if (!rejectingId) return;
-    setIsRejectLoading(true);
-    try {
-      await rejectOrder(rejectingId, rejectionReason.trim());
-      successToast("Orden rechazada correctamente");
-      setRejectingId(null);
-      setRejectionReason("");
-      setRejectionReasonError("");
-      refetch(params);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al rechazar la orden");
-    } finally {
-      setIsRejectLoading(false);
-    }
+    rejectOrder.mutate(
+      { id: rejectingId, rejection_reason: rejectionReason.trim() },
+      {
+        onSuccess: () => {
+          setRejectingId(null);
+          setRejectionReason("");
+          setRejectionReasonError("");
+        },
+      },
+    );
   };
 
-  const handleCancel = async (id: number) => {
-    try {
-      await cancelOrder(id);
-      successToast("Orden anulada correctamente");
-      refetch(params);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al anular la orden");
-    }
-  };
+  const handleCancel = (id: number) => cancelOrder.mutate(id);
 
-  const handleDelete = async (id: number) => {
-    try {
-      await removeOrder(id);
-      successToast("Orden eliminada correctamente");
-      refetch(params);
-    } catch (error: any) {
-      errorToast(error.response?.data?.message || "Error al eliminar la orden");
-    }
-  };
+  const handleDelete = (id: number) => removeOrder.mutate(id);
 
   const columns = useMemo(
     () =>
@@ -297,16 +266,16 @@ export default function ProductionOrderIndexPage() {
             <Button
               variant="outline"
               onClick={() => setRejectingId(null)}
-              disabled={isRejectLoading}
+              disabled={rejectOrder.isPending}
             >
               Cancelar
             </Button>
             <Button
               variant="destructive"
               onClick={handleReject}
-              disabled={isRejectLoading}
+              disabled={rejectOrder.isPending}
             >
-              {isRejectLoading ? (
+              {rejectOrder.isPending ? (
                 <Loader className="h-4 w-4 animate-spin mr-2" />
               ) : (
                 <XCircle className="h-4 w-4 mr-2" />

--- a/src/pages/production-order/components/ProductionOrderItemHistoryDialog.tsx
+++ b/src/pages/production-order/components/ProductionOrderItemHistoryDialog.tsx
@@ -1,0 +1,119 @@
+import { useMemo } from "react";
+import type { ColumnDef } from "@tanstack/react-table";
+import { GeneralModal } from "@/components/GeneralModal";
+import { DataTable } from "@/components/DataTable";
+import {
+  Empty,
+  EmptyDescription,
+  EmptyHeader,
+  EmptyMedia,
+  EmptyTitle,
+} from "@/components/ui/empty";
+import { History, Loader2 } from "lucide-react";
+import { useProductionOrderItemHistory } from "../lib/production-order.hook";
+import type { ProductionOrderItemHistoryEntry } from "../lib/production-order.interface";
+
+interface ProductionOrderItemHistoryDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  itemId: number | null;
+  productName?: string;
+}
+
+export function ProductionOrderItemHistoryDialog({
+  open,
+  onOpenChange,
+  itemId,
+  productName,
+}: ProductionOrderItemHistoryDialogProps) {
+  const { data, isLoading } = useProductionOrderItemHistory(open ? itemId : null);
+
+  const columns = useMemo<ColumnDef<ProductionOrderItemHistoryEntry>[]>(
+    () => [
+      {
+        accessorKey: "document_number",
+        header: "Documento",
+        cell: ({ row }) => (
+          <span className="font-mono font-medium">{row.original.document_number}</span>
+        ),
+      },
+      {
+        accessorKey: "production_date",
+        header: "Fecha de Producción",
+        cell: ({ row }) => <span>{row.original.production_date}</span>,
+      },
+      {
+        accessorKey: "quantity_produced",
+        header: "Cantidad Producida",
+        cell: ({ row }) => (
+          <span className="font-semibold">
+            {Number(row.original.quantity_produced).toFixed(2)}
+          </span>
+        ),
+      },
+      {
+        accessorKey: "produced_by",
+        header: "Producido por",
+        cell: ({ row }) => <span>{row.original.produced_by}</span>,
+      },
+    ],
+    [],
+  );
+
+  const total = (data ?? []).reduce(
+    (sum, entry) => sum + Number(entry.quantity_produced || 0),
+    0,
+  );
+
+  return (
+    <GeneralModal
+      open={open}
+      onClose={() => onOpenChange(false)}
+      title={`Historial de Producción${productName ? ` - ${productName}` : ""}`}
+      subtitle="Documentos de producción generados para este ítem"
+      icon="History"
+      size="3xl"
+      className="max-h-[90vh] overflow-y-auto"
+    >
+      <div className="space-y-4">
+        {isLoading ? (
+          <div className="flex items-center justify-center py-12">
+            <Loader2 className="h-8 w-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : !data || data.length === 0 ? (
+          <Empty className="border border-dashed">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <History />
+              </EmptyMedia>
+              <EmptyTitle>Sin historial de producción</EmptyTitle>
+              <EmptyDescription>
+                Este ítem aún no tiene documentos de producción registrados
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <>
+            <div className="grid grid-cols-2 gap-4 p-4 bg-muted/30 rounded-lg">
+              <div>
+                <p className="text-sm text-muted-foreground">Documentos</p>
+                <p className="text-2xl font-bold">{data.length}</p>
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Total Producido</p>
+                <p className="text-2xl font-bold">{total.toFixed(2)}</p>
+              </div>
+            </div>
+
+            <DataTable
+              columns={columns}
+              data={data}
+              isVisibleColumnFilter={false}
+              variant="default"
+            />
+          </>
+        )}
+      </div>
+    </GeneralModal>
+  );
+}

--- a/src/pages/production-order/components/ProductionOrderPendingPage.tsx
+++ b/src/pages/production-order/components/ProductionOrderPendingPage.tsx
@@ -52,6 +52,16 @@ export default function ProductionOrderPendingPage() {
         ),
       },
       {
+        accessorKey: "warehouse",
+        header: "Almacén",
+        cell: ({ row }) => <span>{row.original.warehouse}</span>,
+      },
+      {
+        accessorKey: "responsible",
+        header: "Responsable",
+        cell: ({ row }) => <span>{row.original.responsible}</span>,
+      },
+      {
         accessorKey: "status",
         header: "Estado",
         cell: ({ row }) => <span>{row.original.status}</span>,

--- a/src/pages/production-order/lib/production-order.hook.ts
+++ b/src/pages/production-order/lib/production-order.hook.ts
@@ -1,90 +1,272 @@
-import { useEffect } from "react";
-import { useQuery } from "@tanstack/react-query";
-import { useProductionOrderStore } from "./production-order.store";
-import type { GetProductionOrdersParams } from "./production-order.interface";
-import { PRODUCTION_ORDER_QUERY_KEY } from "./production-order.interface";
-import { getProductionOrdersSearch } from "./production-order.actions";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import {
+  getProductionOrders,
+  getProductionOrdersSearch,
+  findProductionOrderById,
+  storeProductionOrder,
+  updateProductionOrder,
+  deleteProductionOrder,
+  submitProductionOrder,
+  approveProductionOrder,
+  rejectProductionOrder,
+  cancelProductionOrder,
+  getProductionOrdersSummary,
+  getProductionOrdersPending,
+  getProductionOrderItemHistory,
+} from "./production-order.actions";
+import { PRODUCTION_ORDER, PRODUCTION_ORDER_QUERY_KEY } from "./production-order.interface";
+import type {
+  GetProductionOrdersParams,
+  CreateProductionOrderRequest,
+  UpdateProductionOrderRequest,
+} from "./production-order.interface";
+import type { ProductionOrderSchema } from "./production-order.schema";
+import { ERROR_MESSAGE, SUCCESS_MESSAGE, errorToast, successToast } from "@/lib/core.function";
+
+const { MODEL } = PRODUCTION_ORDER;
+const QUERY_KEY = PRODUCTION_ORDER_QUERY_KEY;
+
+const buildItemsRequest = (items: ProductionOrderSchema["items"]) =>
+  items.map((item) => ({
+    product_id: Number(item.product_id),
+    quantity_requested: Number(item.quantity_requested),
+    labor_cost: item.labor_cost ? Number(item.labor_cost) : 0,
+    // ⚠️ overhead_cost NO se envía: el backend lo calcula automáticamente,
+    // no es un campo que el usuario ingrese manualmente.
+    notes: item.notes || undefined,
+    // ✅ Si el usuario no agregó componentes manualmente, no se envía el
+    // arreglo y el backend autocompleta desde el combo (BOM) del producto.
+    components:
+      item.components && item.components.length > 0
+        ? item.components.map((c) => ({
+            component_id: Number(c.component_id),
+            quantity_required: Number(c.quantity_required),
+            unit_cost: c.unit_cost ? Number(c.unit_cost) : undefined,
+            // ⚠️ waste_quantity/waste_percentage NO se envían: el backend
+            // los calcula automáticamente, igual que overhead_cost.
+            notes: c.notes || undefined,
+          }))
+        : undefined,
+  }));
+
+// Invalidación amplia: cualquier mutación puede afectar el listado, el
+// detalle, el resumen y el reporte de pendientes a la vez, así que se
+// invalida todo el árbol de queries de la entidad en vez de listarlas una
+// por una.
+const invalidateAll = (queryClient: ReturnType<typeof useQueryClient>) =>
+  queryClient.invalidateQueries({ queryKey: [QUERY_KEY] });
+
+// ===== Queries =====
 
 export function useProductionOrders(params?: GetProductionOrdersParams) {
-  const { orders, meta, isLoading, error, fetchOrders } = useProductionOrderStore();
-
-  const page = params?.page;
-  const per_page = params?.per_page;
-
-  useEffect(() => {
-    fetchOrders(params);
-  }, [page, per_page, fetchOrders]);
+  const query = useQuery({
+    queryKey: [QUERY_KEY, "list", params],
+    queryFn: () => getProductionOrders(params),
+    refetchOnWindowFocus: false,
+  });
 
   return {
-    data: orders,
-    meta,
-    isLoading,
-    error,
-    refetch: fetchOrders,
+    data: query.data?.data.data ?? null,
+    meta: query.data?.data.meta ?? null,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
   };
 }
 
 export function useProductionOrdersSearch(params?: Record<string, any>) {
   return useQuery({
-    queryKey: [PRODUCTION_ORDER_QUERY_KEY, "search", params],
+    queryKey: [QUERY_KEY, "search", params],
     queryFn: () => getProductionOrdersSearch(params),
     refetchOnWindowFocus: false,
   });
 }
 
 export function useProductionOrderById(id: number) {
-  const { order, isFinding, error, fetchOrder } = useProductionOrderStore();
-
-  useEffect(() => {
-    if (id) {
-      fetchOrder(id);
-    }
-  }, [id, fetchOrder]);
+  const query = useQuery({
+    queryKey: [QUERY_KEY, "detail", id],
+    queryFn: () => findProductionOrderById(id),
+    enabled: !!id,
+    refetchOnWindowFocus: false,
+  });
 
   return {
-    data: order,
-    isFinding,
-    error,
-    refetch: () => fetchOrder(id),
+    data: query.data?.data.data ?? null,
+    isLoading: query.isLoading,
+    error: query.error,
+    refetch: query.refetch,
   };
 }
 
 export function useProductionOrdersSummary() {
-  const { summary, isLoadingSummary, fetchSummary } = useProductionOrderStore();
+  const query = useQuery({
+    queryKey: [QUERY_KEY, "summary"],
+    queryFn: () => getProductionOrdersSummary(),
+    refetchOnWindowFocus: false,
+  });
 
-  useEffect(() => {
-    fetchSummary();
-  }, [fetchSummary]);
-
-  return { data: summary, isLoading: isLoadingSummary, refetch: fetchSummary };
+  return {
+    data: query.data?.data.data ?? null,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
 }
 
 export function useProductionOrdersPending() {
-  const { pending, isLoadingPending, fetchPending } = useProductionOrderStore();
+  const query = useQuery({
+    queryKey: [QUERY_KEY, "pending"],
+    queryFn: () => getProductionOrdersPending(),
+    refetchOnWindowFocus: false,
+  });
 
-  useEffect(() => {
-    fetchPending();
-  }, [fetchPending]);
-
-  return { data: pending, isLoading: isLoadingPending, refetch: fetchPending };
+  return {
+    data: query.data?.data.data ?? null,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
 }
 
 export function useProductionOrderItemHistory(itemId: number | null) {
-  const { itemHistory, isLoadingItemHistory, fetchItemHistory, resetItemHistory } =
-    useProductionOrderStore();
-
-  useEffect(() => {
-    if (itemId) {
-      fetchItemHistory(itemId);
-    } else {
-      resetItemHistory();
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [itemId]);
+  const query = useQuery({
+    queryKey: [QUERY_KEY, "item-history", itemId],
+    queryFn: () => getProductionOrderItemHistory(itemId!),
+    enabled: !!itemId,
+    refetchOnWindowFocus: false,
+  });
 
   return {
-    data: itemHistory,
-    isLoading: isLoadingItemHistory,
-    refetch: () => (itemId ? fetchItemHistory(itemId) : undefined),
+    data: query.data?.data.data ?? null,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
   };
+}
+
+// ===== Mutations =====
+
+export function useCreateProductionOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: ProductionOrderSchema) => {
+      const request: CreateProductionOrderRequest = {
+        warehouse_origin_id: Number(data.warehouse_origin_id),
+        warehouse_dest_id: Number(data.warehouse_dest_id),
+        responsible_id: Number(data.responsible_id),
+        requested_date: data.requested_date,
+        currency: data.currency || "PEN",
+        observations: data.observations || undefined,
+        items: buildItemsRequest(data.items),
+      };
+      return storeProductionOrder(request);
+    },
+    onSuccess: () => {
+      successToast(SUCCESS_MESSAGE(MODEL, "create"));
+      invalidateAll(queryClient);
+    },
+    onError: (error: any) => {
+      errorToast(error.response?.data?.message || ERROR_MESSAGE(MODEL, "create"));
+    },
+  });
+}
+
+export function useUpdateProductionOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: number; data: Partial<ProductionOrderSchema> }) => {
+      const request: UpdateProductionOrderRequest = {
+        ...(data.warehouse_origin_id && { warehouse_origin_id: Number(data.warehouse_origin_id) }),
+        ...(data.warehouse_dest_id && { warehouse_dest_id: Number(data.warehouse_dest_id) }),
+        ...(data.responsible_id && { responsible_id: Number(data.responsible_id) }),
+        ...(data.requested_date && { requested_date: data.requested_date }),
+        ...(data.currency !== undefined && { currency: data.currency || "PEN" }),
+        ...(data.observations !== undefined && { observations: data.observations || undefined }),
+        ...(data.items && { items: buildItemsRequest(data.items) }),
+      };
+      return updateProductionOrder(id, request);
+    },
+    onSuccess: () => {
+      successToast(SUCCESS_MESSAGE(MODEL, "edit"));
+      invalidateAll(queryClient);
+    },
+    onError: (error: any) => {
+      errorToast(error.response?.data?.message || ERROR_MESSAGE(MODEL, "edit"));
+    },
+  });
+}
+
+export function useDeleteProductionOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => deleteProductionOrder(id),
+    onSuccess: () => {
+      successToast(SUCCESS_MESSAGE(MODEL, "delete"));
+      invalidateAll(queryClient);
+    },
+    onError: (error: any) => {
+      errorToast(error.response?.data?.message || ERROR_MESSAGE(MODEL, "delete"));
+    },
+  });
+}
+
+export function useSubmitProductionOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => submitProductionOrder(id),
+    onSuccess: () => {
+      successToast("Orden enviada a revisión correctamente");
+      invalidateAll(queryClient);
+    },
+    onError: (error: any) => {
+      errorToast(error.response?.data?.message || "Error al enviar la orden");
+    },
+  });
+}
+
+export function useApproveProductionOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => approveProductionOrder(id),
+    onSuccess: () => {
+      successToast("Orden aprobada correctamente");
+      invalidateAll(queryClient);
+    },
+    onError: (error: any) => {
+      errorToast(error.response?.data?.message || "Error al aprobar la orden");
+    },
+  });
+}
+
+export function useRejectProductionOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, rejection_reason }: { id: number; rejection_reason: string }) =>
+      rejectProductionOrder(id, { rejection_reason }),
+    onSuccess: () => {
+      successToast("Orden rechazada correctamente");
+      invalidateAll(queryClient);
+    },
+    onError: (error: any) => {
+      errorToast(error.response?.data?.message || "Error al rechazar la orden");
+    },
+  });
+}
+
+export function useCancelProductionOrder() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: number) => cancelProductionOrder(id),
+    onSuccess: () => {
+      successToast("Orden anulada correctamente");
+      invalidateAll(queryClient);
+    },
+    onError: (error: any) => {
+      errorToast(error.response?.data?.message || "Error al anular la orden");
+    },
+  });
 }

--- a/src/pages/production-order/lib/production-order.hook.ts
+++ b/src/pages/production-order/lib/production-order.hook.ts
@@ -14,7 +14,7 @@ import {
   getProductionOrdersPending,
   getProductionOrderItemHistory,
 } from "./production-order.actions";
-import { PRODUCTION_ORDER, PRODUCTION_ORDER_QUERY_KEY } from "./production-order.interface";
+import { PRODUCTION_ORDER, PRODUCTION_ORDER_QUERY_KEY, flattenPendingReport } from "./production-order.interface";
 import type {
   GetProductionOrdersParams,
   CreateProductionOrderRequest,
@@ -120,7 +120,7 @@ export function useProductionOrdersPending() {
   });
 
   return {
-    data: query.data?.data.data ?? null,
+    data: query.data?.data.data ? flattenPendingReport(query.data.data.data) : null,
     isLoading: query.isLoading,
     refetch: query.refetch,
   };

--- a/src/pages/production-order/lib/production-order.interface.ts
+++ b/src/pages/production-order/lib/production-order.interface.ts
@@ -366,18 +366,15 @@ export function flattenPendingReport(
 }
 
 // ===== HISTORIAL DE PRODUCCIÓN PARCIAL POR ÍTEM =====
-// NOTA: endpoint pendiente de crear/confirmar por el backend
-// (GET /production-order-items/{itemId}/history). Forma asumida en base al
-// flujo de "producción parcial + continuar" descrito por el negocio.
+// ✅ Confirmado con respuesta real (GET /production-order-items/{itemId}/history):
+// una fila por documento de producción generado para el ítem. Las cantidades
+// llegan como string (igual que en el reporte de pendientes) y "produced_by"
+// es el nombre plano del usuario, no un objeto.
 export interface ProductionOrderItemHistoryEntry {
-  id: number;
-  production_order_item_id: number;
-  quantity_produced: number;
-  production_document_id: number | null;
-  produced_by?: ProductionOrderUser | null;
-  observations: string | null;
-  created_at: string;
-  [key: string]: unknown;
+  document_number: string;
+  production_date: string;
+  quantity_produced: string;
+  produced_by: string;
 }
 
 export interface ProductionOrderItemHistoryResponse {

--- a/src/pages/production-order/lib/production-order.interface.ts
+++ b/src/pages/production-order/lib/production-order.interface.ts
@@ -70,7 +70,9 @@ export interface ProductionOrderResource {
 
 export interface ProductionOrderComponentResource {
   id: number;
-  production_order_id: number;
+  // ⚠️ Confirmado con respuesta real: a nivel de ítem viene null (el
+  // componente pertenece al ítem, no directo a la orden).
+  production_order_id: number | null;
   component_id: number;
   component: {
     id: number;
@@ -133,17 +135,69 @@ export interface ProductionOrderUser {
   rol_name: string | null;
 }
 
-// ⚠️ IMPORTANTE — desalineación confirmada con el backend:
-// El POST/PUT de /production-orders acepta "items[]" (varios productos por
-// orden, cada uno con sus propios componentes/BOM). Sin embargo, el
-// GET /production-orders/{id} (confirmado con respuesta real) TODAVÍA NO
-// devuelve esa agrupación por ítem: sigue entregando un único "product" y un
-// solo arreglo plano "components" a nivel de orden (como en el modelo viejo
-// de 1 producto por orden), solo que ahora con waste_quantity/waste_percentage
-// por componente y overhead_cost a nivel de orden.
-// Mientras el backend no exponga "items" en el show, el detalle/edición solo
-// puede reconstruir correctamente órdenes de 1 solo ítem — con varios ítems
-// se perderá la agrupación (se verá todo como si fuera un único producto).
+// ✅ Confirmado con respuesta real (GET /production-orders/{id}): el detalle
+// YA agrupa por ítems igual que el listado — cada producto de la orden viene
+// en "items[]" con sus propias cantidades, costos, estado y su propio BOM
+// ("components"). Ya no hay un "product"/"components" plano a nivel de orden
+// (eso quedó reemplazado por items[]); los totales de cantidad siguen
+// agregados en total_requested/total_produced/total_pending, pero ya no hay
+// un costo total agregado a nivel de orden — los costos viven por ítem
+// (estimated_component_cost/labor_cost/overhead_cost/estimated_total_cost).
+export interface ProductionOrderItemProduct extends ProductionOrderProduct {
+  product_type_id?: number;
+  product_type_name?: string;
+  weight?: number | null;
+}
+
+export interface ProductionOrderDetailItem {
+  id: number;
+  production_order_id: number;
+  product: ProductionOrderItemProduct;
+  product_id: number;
+  quantity_requested: number;
+  quantity_produced: number;
+  quantity_pending: number;
+  progress_percentage: number;
+  estimated_component_cost: number;
+  labor_cost: number;
+  overhead_cost: number;
+  estimated_total_cost: number;
+  status: string;
+  notes: string | null;
+  components: ProductionOrderComponentResource[];
+  // ⚠️ Documentos de producción ya generados para este ítem (batch). Forma
+  // exacta no confirmada aún con datos reales; se deja como desconocida.
+  production_documents: unknown[];
+  created_at: string;
+}
+
+// ⚠️ Confirmado con respuesta real: "responsible" en el detalle viene como
+// la persona plana (mismo shape que un Worker/Person), no envuelta en
+// {name, person: {...}} como "user"/"approved_by". No trae "full_name"
+// armado: hay que componerlo en la UI con names + father_surname + mother_surname.
+export interface ProductionOrderResponsiblePerson {
+  id: number;
+  type_document: string;
+  type_person?: string;
+  number_document: string;
+  names: string;
+  father_surname: string;
+  mother_surname: string;
+  gender?: string | null;
+  birth_date?: string | null;
+  phone?: string | null;
+  email?: string | null;
+  address?: string | null;
+  business_name?: string | null;
+  commercial_name?: string | null;
+  driver_license?: string | null;
+  user_id?: number | null;
+  created_at?: string;
+  roles?: unknown[];
+  hire_date?: string | null;
+  vacation_days_per_year?: number | null;
+}
+
 export interface ProductionOrderDetailResource {
   id: number;
   order_number: string;
@@ -154,33 +208,23 @@ export interface ProductionOrderDetailResource {
   processed_at: string | null;
   created_at: string;
   updated_at: string;
-  quantity_requested: number;
   currency: string;
-  estimated_component_cost: number;
-  labor_cost: number;
-  overhead_cost: number;
-  estimated_total_cost: number;
   observations: string | null;
   rejection_reason: string | null;
+  total_requested: number;
+  total_produced: number;
+  total_pending: number;
+  items: ProductionOrderDetailItem[];
   company_id: number;
   warehouse_origin_id: number;
   warehouse_dest_id: number;
-  product_id: number | null;
   user_id: number;
   responsible_id: number;
-  production_document_id: number | null;
-  // ⚠️ Confirmado con respuesta real: cuando la orden no tiene ítem/producto
-  // asociado (product_id null), el backend responde "product": null (y
-  // puede omitir "components" por completo). Ambos deben tratarse como
-  // opcionales/nulos en la UI.
-  product: ProductionOrderProduct | null;
   warehouse_origin: ProductionOrderWarehouse;
   warehouse_dest: ProductionOrderWarehouse;
   user: ProductionOrderUser;
-  responsible: ProductionOrderUser;
+  responsible: ProductionOrderResponsiblePerson;
   approved_by: ProductionOrderUser | null;
-  components?: ProductionOrderComponentResource[];
-  production_document?: null | object;
 }
 
 // ===== API RESPONSES =====
@@ -255,32 +299,70 @@ export interface ProductionOrderSummaryResponse {
 }
 
 // ===== REPORTE: ÓRDENES/ÍTEMS PENDIENTES A PRODUCIR =====
-// NOTA: al momento de documentar, /production-orders/pending devolvía
-// "data": [] (sin órdenes aprobadas pendientes de producir en ese momento),
-// por lo que la forma exacta de cada fila no está confirmada por el backend.
-// Se modela con los campos más probables (orden + ítem + saldo pendiente)
-// y se debe ajustar cuando el backend entregue un ejemplo con datos reales.
-export interface ProductionOrderPendingItem {
+// ⚠️ Confirmado con respuesta real (GET /production-orders/pending): "data"
+// NO es un arreglo, es un objeto agrupado por order_id (las claves son el
+// order_id como string). Cada grupo trae los datos de la orden y un arreglo
+// "items" con los ítems pendientes de esa orden (cantidades como string,
+// salvo quantity_pending que llega numérico).
+export interface ProductionOrderPendingReportItem {
+  item_id: number;
+  product: string;
+  quantity_requested: string;
+  quantity_produced: string;
+  quantity_pending: number;
+  status: string;
+}
+
+export interface ProductionOrderPendingReportOrder {
   order_id: number;
   order_number: string;
   status: ProductionOrderStatus;
   requested_date: string;
-  approved_at: string | null;
-  item_id: number;
-  product_id: number;
-  product_name: string;
-  quantity_requested: number;
-  quantity_produced: number;
-  quantity_pending: number;
-  warehouse_origin_id?: number;
-  warehouse_dest_id?: number;
-  responsible_id?: number;
-  [key: string]: unknown;
+  warehouse: string;
+  responsible: string;
+  items: ProductionOrderPendingReportItem[];
 }
 
 export interface ProductionOrderPendingResponse {
   message: string;
-  data: ProductionOrderPendingItem[];
+  data: Record<string, ProductionOrderPendingReportOrder>;
+}
+
+// Fila aplanada (una por ítem pendiente) que consume la tabla de la UI.
+export interface ProductionOrderPendingItem {
+  order_id: number;
+  order_number: string;
+  requested_date: string;
+  warehouse: string;
+  responsible: string;
+  item_id: number;
+  product_name: string;
+  quantity_requested: number;
+  quantity_produced: number;
+  quantity_pending: number;
+  status: string;
+}
+
+// El backend agrupa por orden; la tabla necesita una fila por ítem, así que
+// se aplana aquí una sola vez y lo reutilizan el hook y el store.
+export function flattenPendingReport(
+  data: Record<string, ProductionOrderPendingReportOrder>
+): ProductionOrderPendingItem[] {
+  return Object.values(data).flatMap((order) =>
+    order.items.map((item) => ({
+      order_id: order.order_id,
+      order_number: order.order_number,
+      requested_date: order.requested_date,
+      warehouse: order.warehouse,
+      responsible: order.responsible,
+      item_id: item.item_id,
+      product_name: item.product,
+      quantity_requested: Number(item.quantity_requested),
+      quantity_produced: Number(item.quantity_produced),
+      quantity_pending: item.quantity_pending,
+      status: item.status,
+    }))
+  );
 }
 
 // ===== HISTORIAL DE PRODUCCIÓN PARCIAL POR ÍTEM =====

--- a/src/pages/production-order/lib/production-order.interface.ts
+++ b/src/pages/production-order/lib/production-order.interface.ts
@@ -17,10 +17,30 @@ export type ProductionOrderStatus =
   | "ANULADO";
 
 // ===== API RESOURCES (LIST) =====
-// NOTA: el endpoint de listado (GET /production-orders) todavía devuelve
-// campos agregados a nivel de orden (product_id/quantity_requested únicos),
-// aunque la orden ya admita varios ítems al crearse/editarse. Se deja tal
-// cual responde hoy el backend.
+// ⚠️ Confirmado con respuesta real (GET /production-orders): el listado YA
+// agrupa por ítems (varios productos por orden), a diferencia del detalle
+// (show, más abajo) que todavía entrega producto/componentes planos a nivel
+// de orden. El listado ya no trae product_id/quantity_requested/costos a
+// nivel de orden ni production_document_id: los costos y cantidades ahora
+// viven por ítem, y los totales de cantidad se agregan en total_requested/
+// total_produced/total_pending.
+
+export interface ProductionOrderListItem {
+  id: number;
+  production_order_id: number;
+  product_id: number;
+  quantity_requested: number;
+  quantity_produced: number;
+  quantity_pending: number;
+  progress_percentage: number;
+  estimated_component_cost: number;
+  labor_cost: number;
+  overhead_cost: number;
+  estimated_total_cost: number;
+  status: string;
+  notes: string | null;
+  created_at: string;
+}
 
 export interface ProductionOrderResource {
   id: number;
@@ -32,21 +52,18 @@ export interface ProductionOrderResource {
   processed_at: string | null;
   created_at: string;
   updated_at: string;
-  quantity_requested: number;
   currency: string;
-  estimated_component_cost: number;
-  labor_cost: number;
-  overhead_cost: number;
-  estimated_total_cost: number;
   observations: string | null;
   rejection_reason: string | null;
+  total_requested: number;
+  total_produced: number;
+  total_pending: number;
+  items: ProductionOrderListItem[];
   company_id: number;
   warehouse_origin_id: number;
   warehouse_dest_id: number;
-  product_id: number;
   user_id: number;
   responsible_id: number;
-  production_document_id: number | null;
 }
 
 // ===== API RESOURCES (DETAIL - SHOW) =====
@@ -127,15 +144,43 @@ export interface ProductionOrderUser {
 // Mientras el backend no exponga "items" en el show, el detalle/edición solo
 // puede reconstruir correctamente órdenes de 1 solo ítem — con varios ítems
 // se perderá la agrupación (se verá todo como si fuera un único producto).
-export interface ProductionOrderDetailResource extends ProductionOrderResource {
-  product: ProductionOrderProduct;
+export interface ProductionOrderDetailResource {
+  id: number;
+  order_number: string;
+  status: ProductionOrderStatus;
+  status_badge: string;
+  requested_date: string;
+  approved_at: string | null;
+  processed_at: string | null;
+  created_at: string;
+  updated_at: string;
+  quantity_requested: number;
+  currency: string;
+  estimated_component_cost: number;
+  labor_cost: number;
+  overhead_cost: number;
+  estimated_total_cost: number;
+  observations: string | null;
+  rejection_reason: string | null;
+  company_id: number;
+  warehouse_origin_id: number;
+  warehouse_dest_id: number;
+  product_id: number | null;
+  user_id: number;
+  responsible_id: number;
+  production_document_id: number | null;
+  // ⚠️ Confirmado con respuesta real: cuando la orden no tiene ítem/producto
+  // asociado (product_id null), el backend responde "product": null (y
+  // puede omitir "components" por completo). Ambos deben tratarse como
+  // opcionales/nulos en la UI.
+  product: ProductionOrderProduct | null;
   warehouse_origin: ProductionOrderWarehouse;
   warehouse_dest: ProductionOrderWarehouse;
   user: ProductionOrderUser;
   responsible: ProductionOrderUser;
   approved_by: ProductionOrderUser | null;
-  components: ProductionOrderComponentResource[];
-  production_document: null | object;
+  components?: ProductionOrderComponentResource[];
+  production_document?: null | object;
 }
 
 // ===== API RESPONSES =====

--- a/src/pages/production-order/lib/production-order.store.ts
+++ b/src/pages/production-order/lib/production-order.store.ts
@@ -25,7 +25,7 @@ import {
 } from "./production-order.actions";
 import type { ProductionOrderSchema } from "./production-order.schema";
 import { ERROR_MESSAGE, errorToast } from "@/lib/core.function";
-import { PRODUCTION_ORDER } from "./production-order.interface";
+import { PRODUCTION_ORDER, flattenPendingReport } from "./production-order.interface";
 import type { Meta } from "@/lib/pagination.interface";
 
 const { MODEL } = PRODUCTION_ORDER;
@@ -242,7 +242,7 @@ export const useProductionOrderStore = create<ProductionOrderStore>((set) => ({
     set({ isLoadingPending: true });
     try {
       const response = await getProductionOrdersPending();
-      set({ pending: response.data.data, isLoadingPending: false });
+      set({ pending: flattenPendingReport(response.data.data), isLoadingPending: false });
     } catch {
       set({ isLoadingPending: false });
       errorToast("Error al cargar el reporte de pendientes a producir");


### PR DESCRIPTION
Extends product CRUD/UI to handle `weight` end-to-end (defaults, schema validation, form input, FormData payload, table column, and resource typing). Adds a production-order item history dialog with summary/table and integrates it from the order detail cards via a new Historial action, updating interfaces to match the confirmed API response shape. Also fixes production document actions by using `ROUTE_UPDATE` and showing “Actualizar” only for BORRADOR while keeping cancellation for PROCESADO.